### PR TITLE
OP-280 User Manual refactoring: links

### DIFF
--- a/doc_user/UserManual.adoc
+++ b/doc_user/UserManual.adoc
@@ -13,13 +13,16 @@ image:by-sa.png[bysa,width=88,height=31,link="http://creativecommons.org/license
 pass:[<br>][.small]#User's Guide, &#169; 2020 by https://www.informaticisenzafrontiere.org/[Informatici Senza Frontiere Onlus]#
 pass:[<br>][.small]#Policies is made available under a http://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0] International License: http://creativecommons.org/licenses/by-sa/4.0/.#
 
-== OpenHospital
+== Open Hospital
 
 == 1 Abstract
 
-This application is the first of a set of software products that ISFfootnote:[Informatici Senza Frontiere = Computer scientists without frontiers] has developed to support the management and the activities of the St. Luke Hospital in Angal (Uganda). After that mission, the St. Luke Hospital has become only the first one of a long list of hospitals that found this software useful.
+This application is the first of a series of software products that ISFfootnote:[Informatici Senza Frontiere = Computer scientists without frontiers] has developed
+to support the management and the activities of the St. Luke Hospital in Angal (Uganda). After the successful installation and use,
+the St. Luke Hospital is the first of a long list of hospitals that found this software useful.
 
-All the work was realized as an open-sourcefootnote:[Open-source = software for which the original *source code* is made available to anyone free of charge.] project using only open-source development software.
+All the work on this software is done as an open-sourcefootnote:[Open-source = software for which the original *source code* is
+made available to anyone free of charge.] project using only open-source development software.
 
 This application software consists of the following parts:
 
@@ -36,88 +39,107 @@ This application software consists of the following parts:
 * Appointments management
 * Statistics and printing
 
-This document describes how all the above-mentioned items work and gives you some suggestions on the correct use of the program.
+This document describes how all the above-mentioned items work and gives you some suggestions as to the correct use of the program.
 
-The reader will not find in this manual the information he needs for the installation of the application software or for administrative purposes; to have such information you should consult our Administrator’s Guide, supplied with the application software.
+The reader will not find in this manual the information one needs for the installation of the application software or 
+for administrative purposes; that information is provided in the _Administrator’s Guide_ supplied with the application software.
 
 == 2 Introduction
 
-The aim of this program is to manage, in the simplest manner, the hospital administrative operations like registering patients and laboratory analysis, and to produce statistics for the health ministry. In the following chapters the users will find all the information they need in order to use properly the program.
+The aim of this program is to manage, in the simplest manner, the hospital administrative operations like registering patients 
+and laboratory analysis, and to produce statistics for the health ministry. In the following chapters the users will find all 
+the information they need in order to use properly the program.
 
-== 3 Useful Information before reading this user manual.
+== 3 Useful Information before reading this user manual
 
 === 3.1 Help
 
-* The *[.underline]##H##ELP* function available on the bottom of the main MENU of OpenHospital allows you to access [.underline]#offline# this document.
+* The *[.underline]##H##ELP* function available on the bottom of the main MENU of Open Hospital allows you to access
+this document [.underline]#offline#.
 
-=== 3.2 Legenda
+=== 3.2 Legend
 
-In this document will be used following conventions:
+In this document the following conventions are used:
 
-* When in the text of this document you find a word written in bold and highlighted in grey *–* like *[.underline]##P##harmacy* or *[.underline]##N##ew –* it indicates a function of the application and it is also called “button”. *[.underline]##P##harmacy* is a button.
+* When in the text of this document you find a word written in bold and highlighted in grey *–*
+like *[.underline]##P##harmacy* or *[.underline]##N##ew –* it indicates a function of the application and it is also
+called a “button”. *[.underline]##P##harmacy* is a button.
 
-* When you find a text written in bold Italic (as an example *_Laboratory browsing)_* it indicates the screen with name “Laboratory browsing” (see example below). Each screen of the application is called window. *_Laboratory browsing_* is a window.
-* When you find a text written in bold as - *Search patient visits –* it indicates a function of the application, or an area of the window (as an example *Data table*).
+* When you find a text written in bold Italic (as an example *_Laboratory browsing)_* it indicates the screen with name
+“Laboratory browsing” (see example below). Each screen of the application is called a window. *_Laboratory browsing_* is a window.
 
-* Each button has always one letter with an underscore. You can select the functionality offered by the button pressing the “Alt” key and at the same time the “underscored” key (in the example of *[.underline]##P##harmacy* you have to press “Alt” and “P”)*.* This behaviour is common all over the application and allows the user to operate (almost) without the use of the mouse. In the entire document “Alt” key and the “P” key will be indicated as “Alt + P”.
+* When you find a text written in bold as - *Search patient visits –* it indicates a function of the application,
+or an area of the window (for example, *Data table*).
+
+* Each button always has a single letter with an underscore. You can select the functionality offered by the button by
+pressing the “Alt” key and at the same time the “underscored” key (in the example of *[.underline]##P##harmacy* you
+press “Alt” and “P”)*.* This behavior is common all over the application and allows the user to operate (almost)
+without the use of the mouse. In the entire document “Alt” key and the “P” key will be indicated as “Alt + P”.
 
 .Click with the mouse on the button or press "Alt + P" to enter the *Pharmacy*
-[#3-default-main-menu]
+[#default-main-menu-3]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
-* Each screen of the application is called “window”. Most complex windows of the application are composed by more than one area. Areas can be *Selection panel*, *Data table* and *Buttons panel* (see *_Laboratory browsing_* window below)
+* Each screen of the application is a called “window”. Most complex windows of the application are composed of more than one
+area. Areas can be *Selection panel*, *Data table* or *Buttons panel* (see *_Laboratory browsing_* window below).
 
 image:image3.png[../../Screen%20Shot%202019-07-26%20at%2015.15.43.png,width=642,height=464]
 
-* Highlight of a record. To highlight a record (it is a line on a *Data table*) you have to click with the mouse on the record. The record (all the line) will be highlighted in blue. This is valid all over the application (see example below):
+* To highlight a record (for example a single line in a *Data table*) you click the mouse on the record.
+The record (the entire line) is then highlighted in blue. This is valid all over the application (see example below):
 
 image:image4.png[../../Screen%20Shot%202019-07-26%20at%2015.16.05.png,width=509,height=296]
 
 ==  4 Run the application
 
-After double-clicking the program icon on your desktop, you will see an information image (splash image) for a few seconds and then the main _menu_ of the OpenHospital application will appear.
+After double-clicking the program icon on your desktop, you will see an information image (splash image) for a few seconds and
+then the main _menu_ of the Open Hospital application.
 
 .The default Main Menu when the application starts.
-[#4-default-main-menu]
+[#default-main-menu-4]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
-From a menu you can get to another menu of deeper level, as in the example below. From the main *_menu_* you get the *_General data_* menu, or you can directly go in a function of the application (see the following example with the browser *_OPD Out Patient Department_*.
+From a menu you can get to another menus or functional areas.  In the example below, from the main *_menu_*
+selecting the *_General Data_* menu leads to another menu of data types:
 
 image:image6.png[../../Screen%20Shot%202019-07-26%20at%2015.19.33.png,width=602,height=370]
 
-or you can directly go in a function of the application, as following example:
+Some menu selections lead directly to a function of the application
+(see the following example with the browser *_OPD Out Patient Department_*):
 
 image:image7.png[../../Screen%20Shot%202019-07-26%20at%2015.20.05.png,width=649,height=374]
 
 <<<
 
+[#outpatient-department-management]
 == 5 Outpatient Department Management ([.underline]##O##PD)
 
 === 5.1 Main Characteristics
 
-Out Patient Department functionalities allow to record Ambulatory Patient visits, search, review, edit and eventually delete visits, and allows queries necessary for statistical purposes.
+The function of the Out Patient Department allows for recording Ambulatory Patient visits, searching, reviewing, editing and
+eventually deleting visits.  In addition queries necessary for statistical purposes are available.
 
-Click on *[.underline]##O##PD* button or press “Alt + O” in the main *_menu_* to access OPD function.
+Click on the *[.underline]##O##PD* button or press “Alt + O” in the main *_menu_* to access OPD function.
 
 .Press *[.underline]##O##PD* button or “Alt + O”.
-[#5-default-main-menu]
+[#default-main-menu-5]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
 === 5.2 Functions of Out Patient Department
 
-All functions available under *[.underline]##O##PD* are accessible from the window *_OPD Out Patient Department_* showed below.
+All functions available under *[.underline]##O##PD* are accessible from the window *_OPD Out Patient Department_* shown below.
 
 image:image9.png[image,width=800,height=319]
 
 The following functions are available from the *Buttons Panel* of the window *_OPD Out Patient Department_:*
 
-* *[.underline]##N##ew* to create a new patient visit
-* *[.underline]##E##dit* to modify an already stored patient visit
-* *[.underline]##D##elete* to delete a patient visit
-* *[.underline]##C##lose* to exit from the function *_OPD Out Patient Department_*
+* *[.underline]##N##ew* create a new patient visit
+* *[.underline]##E##dit* modify an already stored patient visit
+* *[.underline]##D##elete* delete a patient visit
+* *[.underline]##C##lose* exit from the function *_OPD Out Patient Department_*
 
 Furthermore, a search function (*[.underline]##S##earch*) is available using the *Selection Panel* on the left of the window.
 
@@ -125,69 +147,91 @@ Furthermore, a search function (*[.underline]##S##earch*) is available using the
 
 Queries about Ambulatory Patient Visits can be done using the search criteria available on the *Selection Panel* area of the window (left side of the window).
 
-Doing the selection, data about patients can be selected by choosing specific fields among the following ones:
+The following fields are available to select or narrow the resulting matches:
 
-* *Disease type.* You can select one or all disease types
-* *Disease.* You can select one or all the diseases or search by typing some letters in the search field
-* **Date. “**DATE From” and “DATE To” allow the selection of all the visits performed over the requested period
-* **Age. “**Age From” and “Age To” allow the selection of all the patients by age
-* *Sex.* Allow the selection of all the patients by sex: All / Male / Female
-* *Type of patient.* Allow the selection of all the visits by attendance: All / New / Re-Attendance
-* *Count.* Counter at the bottom counts for you how many visits match your criteria after pressing the *[.underline]##S##earch* button.
+* *Disease type.* Allows for selection by a specific disease type or all disease types
+* *Disease.* Allows for selection by a specific disease, or all diseases, or searching for matches by typing some letters in the search field
+* **Date. “**DATE From” and “DATE To” allows for selection of all visits performed during a requested period
+* **Age. “**Age From” and “Age To” allows for the selection of the patients by age
+* *Sex.* Allows for selection of all the patients by sex: All / Male / Female
+* *Type of patient.* Allows for selection of all the visits by attendance: All / New / Re-Attendance
 
-After having chosen press *[.underline]##S##earch* button. The system will show on the *Data table* area results of the search applying criteria requested by you.
+After providing the selection criteria, press the *[.underline]##S##earch* button.
+The counter at the bottom of the window indicates how many visits match the specified criteria
+and the individual visit data appears in the *Data table* area.
 
-In the example hereinafter all the visits of patients with Asthma disease admitted in the period from 2006-11-01 until 2006-11-15 of all the ages, all sex, all patient types are showed.
+In the example below shows all the visits of patients with Asthma disease admitted in the period from 2006-11-01 until
+2006-11-15 of all ages, all sexes, and all patient types.
 
 image:image10.png[image,width=810,height=337]
 
+[#create-a-new-patient-visit]
 ==== 5.2.2 Create a new patient visit ([.underline]##N##ew)
 
-Press *[.underline]##N##ew* button in the *_OPD Out Patient Department_* window to access the *_New OPD registration_* window showed below.
+Press the *[.underline]##N##ew* button in the *_OPD Out Patient Department_* window to access the *_New OPD registration_* window shown below.
 
 image:image11.png[image,width=391,height=435]
 
 To record a visit, enter the following fields:
 
-* *Type of attendance.* This field is not meant to distinguish whether an individual is new or not in the ambulatory (absolutely first time he/she enters the ambulatory). The NEW ATTENDANCE is devoted to cases when Patient (at his first or n-th time in the ambulatory it does not care here) comes to the Ambulatory to report a new health issue / new disease for which no care has already been addressed and recorded. The re-attendance is – on the contrary – the case of records created when a Patient comes back to the Ambulatory in order to follow-up a past new attendance when he/she received cares and previous instructions to recover.
+* *Type of attendance.* This field is not meant to distinguish whether an individual is new or not in the ambulatory
+(that is, whether this is absolutely first time he/she enters the ambulatory). The NEW ATTENDANCE selection
+indicates whether the Patient comes to the ambulatory to report a new
+health issue or new disease for which no care has been previously addressed or recorded.  This could be their initial
+visit or their n-th time in the ambulatory, it does not matter with regards to this field.  If this visit is for an
+issue or disease previously addressed the field is not selected and records are created for the patient
+with regards to the follow-up care and instructions for recovery.
  +
  +
-_Example: a Patient comes to the ambulatory because he/she reports a cut ==> this event is recorded as NEW ATTENDANCE and Doctor sutures the wound and invites Patient to come back ten days later; then same patient comes back after ten days to have his/her stitches removed: a new OPD record is then created but with no NEW ATTENDANCE flag set._
+_Example: A patient comes to the ambulatory because he/she reports a cut ==> this event is recorded as
+NEW ATTENDANCE and Doctor sutures the wound and invites Patient to come back ten days later; when the same patient comes back
+after ten days to have his/her stitches removed, a new OPD record is then created but without the NEW ATTENDANCE flag set._
  +
-* *Date of the visit*. Date in which Patient is met for recorded activity.
-* *Disease Type:* By selecting a _DiseaseType_ the first diagnosis list will contain only its related diseases. Second and third list will still contain all diseases.
- +
- +
-_Example: Disease Types can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
- +
-* *Diagnosis.* Maximum three diseases can be diagnosed per each attendance (“new attendance” or “re-attendance” it does not care in this context). Normally patient reports at least one visit reason but it may happen that during same visit the Doctor finds other concurrent pathologies thus here possibility is given to record till maximum three (the first being the only one mandatory). +
-It is possible to filter in order to find diseases more easily. To do so, you will need to enter a text fragment in the search field that is part of the disease name. The closer the search text comes to the name of the disease being searched, the more precise the search is. 
+* *Date of the visit*. The date in which Patient is seen for the recorded activity.
+* *Disease Type:* By selecting a _DiseaseType_, the first diagnosis list will contain only related diseases.
+The second and third list still contains all diseases.
  +
  +
-_Example: in the *OPD Out Patient Department* window only first diagnosis and its type will be show, anyway all data are stored and processed in reports and searching._
+_Example: Disease Types can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document._
  +
-* *Patient age*. Validity range is 0-200.
+* *Diagnosis.* A maximum of three diseases can be diagnosed per each attendance (“new attendance” or “re-attendance”
+it does not matter in this context). Normally patient reports at least one visit reason but it may happen that
+during same visit the Doctor finds other concurrent pathologies thus here possibility is given to record
+until maximum three (the first being the only one mandatory). +
+It is possible to filter in order to find diseases more easily.
+To do so, you will need to enter a text fragment in the search field that is part of the disease name.
+The closer the search text comes to the name of the disease being searched, the more precise the search is.
+ +
+ +
+_Example: In the *OPD Out Patient Department* window only the first diagnosis and its type is shown,
+but all the corresponding data is stored and available in reports and for searching._
+ +
+* *Patient age*. Validity range is 0-200
 * *Patient sex*. Male/female
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm and record patient visits
+* *[.underline]##O##K* to confirm and record patient visits
 * *[.underline]##C##ancel* to close the window and to return to the Menu
 
 ==== 5.2.3 Modify a recorded patient visit ([.underline]##E##dit)
 
-First of all, to modify a visit you have to highlight it in the *_OPD Out Patient Department_* window. Once you’ve done this, press the *[.underline]##E##dit* button. When the *_Edit OPD registration_* window showed below appears, the record is available for changes. All data can be changed.
+First of all, to modify a visit you have to highlight it in the *_OPD Out Patient Department_* window. Once you have done this,
+press the *[.underline]##E##dit* button. When the *_Edit OPD registration_* window shown below appears, the record is available for changes. All data can be changed.
 
 image:image12.png[image,width=373,height=414]
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm new values (all the previous values will be lost)
+* *[.underline]##O##K* to confirm new values (all the previous values will be lost)
 * *[.underline]##C##ancel* to close the window and to return to the *_OPD Out Patient Department_* window without applying any change.
 
 ==== 5.2.4 Delete a recorded patient visit ([.underline]##D##elete)
 
-First of all, to delete a stored visit you have to highlight it in the *_OPD Out Patient Department_* window. Secondly press the *[.underline]##D##elete* button. The highlighted record will be showed as in the *_New Hospital_* window below. Now the record can be deleted. Deleted records won’t be available anymore.
+First of all, to delete a stored visit you have to highlight it in the *_OPD Out Patient Department_* window. 
+Secondly press the *[.underline]##D##elete* button. The highlighted record will be shown as in the 
+*_New Hospital_* window below. Now the record can be deleted. Deleted records are not longer available.
 
 image:image13.png[image,width=278,height=206]
 
@@ -198,11 +242,12 @@ In the *Buttons Panel* you have the following choices:
 
 === 5.3 OPD Extended (OPD v1.4)
 
-Since OpenHospital version 1.3.1 you can extend the OPD functionality by changing the _OPDEXTENDED_ flag in the configuration file. Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+Since Open Hospital version 1.3.1 you can extend the OPD functionality by changing the _OPDEXTENDED_ flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 ==== 5.3.1 New features
 
-Press *[.underline]##N##ew* button in the *_OPD Out Patient Department_* window to access the *_New OPD registration (1.4)_* window showed below.
+Press the *[.underline]##N##ew* button in the *_OPD Out Patient Department_* window to access the 
+*_New OPD registration (1.4)_* window shown below.
 
 image:image14.png[OPD Edit Extended v1.4,width=1024,height=771]
 
@@ -217,9 +262,10 @@ The OPD Extended module affords the following improvements:
 * in case of editing an old OPD it is possible to change everything except the patient, which the OPD refers to, and the "new-attendance" check box;
 * in case the selected patient needs to update his/her personal data, you can do it by clicking on the Edit icon image:image15.png[edit_button.png,width=26,height=26] near his/her name; a new window will appear with the patient personal information to let you change them;
 * in case the patient is not yet registered, the *_<new patient>_* entry can be selected to let you register the new patient; after registration you will be direct back to the OPD window and the new patient will be selected.
-* If the user is enabled by the admin (see <<_15_users_groups_file_users>>):
-** you will see also the *Examination* button function (see <<_10_5_2_patient_examination>>).
-** you will see also the *Operation* tab after the Patient's one (5) in order to record small surgeries and other interventions (see <<_14_7_operations_operation>>) as well as in Admission (see <<_10_5_3_insertmodify_surgery_data>>).
+* If the user is enabled by the Administrator (see <<users-groups,Users & Groups>>):
+** you will see also the *Examination* button function (see <<patient-examination,Patient examination>>).
+** you will see also the *Operation* tab after the Patient's one (5) in order to record small surgeries and other interventions (see
+<<operations,Operations>>) as well as in Admission (see <<insert-or-modify-surgery-data,Insert or Modify Surgery Data>>).
 
 <<<
 
@@ -227,7 +273,7 @@ The OPD Extended module affords the following improvements:
 
 By pressing *[.underline]##P##harmacy* from the main menu, you access the Pharmacy menu. From this menu you have the following functions available: *[.underline]##P##harmaceuticals* and *[.underline]##P##harmaceuticals Stock*, *[.underline]##P##harmaceuticals Stock Ward.*
 
-.Press *[.underline]##P##harmacy* button or “Alt + P” to open the Pharmacy Sub-Menu
+.Press the *[.underline]##P##harmacy* button or “Alt + P” to open the Pharmacy Sub-Menu
 [frame=none]
 [grid=none]
 [caption="Sub Menu: "]
@@ -236,8 +282,9 @@ By pressing *[.underline]##P##harmacy* from the main menu, you access the Pharma
 |===
 
 
-NOTE: _Pharmaceuticals Stock Ward functionality can be disabled by changing the INTERNALPHARMACIES flag in the configuration file**.** Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: Pharmaceuticals Stock Ward functionality can be disabled by changing the INTERNALPHARMACIES flag in the configuration file**.** Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
+[#pharmaceuticals]
 === 6.1 Pharmaceuticals ([.underline]##P##harmaceuticals)
 
 ==== 6.1.1 Main Characteristics
@@ -249,13 +296,15 @@ Pharmaceutical functions allow you to insert, to modify and to delete pharmaceut
 * if the pharmaceutical is out of stock
 * the expiring drugs within today or a period
 
-NOTE: _in OpenHospital to identify pharmaceuticals sometimes is used the word “pharmaceutical” and in others the synonymous “Medical”._
+NOTE: In Open Hospital to identify pharmaceuticals sometimes word “pharmaceutical” is used and
+sometimes the synonym “Medical” is used.
 
 ==== 6.1.2 Functions of pharmaceuticals
 
 To access the functions of Pharmaceuticals, press *[.underline]##P##harmaceuticals* on the Pharmacy menu.
 
-All functions available under Pharmaceuticals are accessible from the *_Pharmaceutical browsing window_* showed below. It displays all the pharmaceuticals available in the hospital.
+All functions available under Pharmaceuticals are accessible from the *_Pharmaceutical browsing window_* 
+shown below. It displays all the pharmaceuticals available in the hospital.
 
 image:image17.png[image,width=548,height=262]
 
@@ -280,9 +329,10 @@ On the left a particular combo box is placed. According to its selection, the ta
 
 Since version 1.8.4, it is possible to sort the table by any of the column header by double clicking on its column name. Filtered type (combo box), searched keys (the aside field) and sorting are reflected in the STOCK report.
 
+[#insert-a-new-pharmaceutical]
 ===== 6.1.2.1 Insert a new pharmaceutical ([.underline]##N##ew)
 
-Press *[.underline]##N##ew* button in the *_Pharmaceutical browsing_* window to access the *_New medical record_* window showed below.
+Press the *[.underline]##N##ew* button in the *_Pharmaceutical browsing_* window to access the *_New medical record_* window shown below.
 
 To insert a new pharmaceutical, enter the following fields:
 
@@ -292,24 +342,24 @@ To insert a new pharmaceutical, enter the following fields:
 * *PcsXPck*: Pieces per packet (if more than 1)
 * *Critical level*: the minimum quantity required in stock
 
-NOTE: _Types can be defined by the Administrator. Ask to your Administrator how to do it see link:#14-general-data-general-data[General Data] in this document._
+NOTE: Types can be defined by the Administrator. See <<general-data,General Data>> in this document for more information.
 
 image:image18.png[image,width=350,height=263]
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm data
+* *[.underline]##O##K* to confirm data
 * *[.underline]##C##ancel* to close the window and to return to the Menu
 
 ===== 6.1.2.2 Modify an existing pharmaceutical ([.underline]##E##dit)
 
-Press *[.underline]##E##dit* button in the *_Pharmaceutical browsing_* window to access the *_Editing medical record_* window showed below. You can modify all data unless “Type”
+Press the *[.underline]##E##dit* button in the *_Pharmaceutical browsing_* window to access the *_Editing medical record_* window shown below. You can modify all data unless “Type”
 
 image:image19.png[image,width=350,height=280]
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm data
+* *[.underline]##O##K* to confirm data
 * *[.underline]##C##ancel* to close the window and to return to the Menu
 
 ===== 6.1.2.3 Delete a pharmaceutical ([.underline]##D##elete)
@@ -325,9 +375,9 @@ In the *Buttons Panel* you have the following choices:
 
 ===== 6.1.2.4 Export the list of pharmaceuticals ([.underline]##E##xport)
 
-Use this function to export on excel the list of pharmaceuticals showed in the *_Pharmaceutical browsing_* window.
+Use this function to export into Excel the list of pharmaceuticals shown in the *_Pharmaceutical browsing_* window.
 
-Press *[.underline]##E##xport* button in the *_Pharmaceutical browsing_* window to access the *_Save_* window showed below. It will be in the language of your computer, no matter the language used in OpenHospital.
+Press the *[.underline]##E##xport* button in the *_Pharmaceutical browsing_* window to access the *_Save_* window shown below. It will be in the language of your computer, no matter the language used in Open Hospital.
 
 Then you can start the export of the list of pharmaceuticals.
 
@@ -341,16 +391,17 @@ image:image21.png[image,width=452,height=319]
 
 ===== 6.1.2.5 Stock report ([.underline]##S##TOCK)
 
-Press *[.underline]##S##TOCK* button in the *_Pharmaceutical browsing_* window to produce the report of pharmaceuticals in the stock grouped by _IN STOCK_ and _OUT OF STOCK_.
+Press the *[.underline]##S##TOCK* button in the *_Pharmaceutical browsing_* window to produce the report of pharmaceuticals in the stock grouped by _IN STOCK_ and _OUT OF STOCK_.
 
 ===== 6.1.2.6 Order of pharmaceuticals ([.underline]##O##rder)
 
-Press *[.underline]##O##rder* button in the *_Pharmaceutical browsing_* window to produce the list of pharmaceuticals remaining in stock and the ones to be reordered according with their critical level.
+Press the  *[.underline]##O##rder* button in the *_Pharmaceutical browsing_* window to produce the list of pharmaceuticals remaining in stock and the ones to be reordered according with their critical level.
 
 ===== 6.1.2.7 Order of pharmaceuticals ([.underline]##E##xpiring)
 
-Press *[.underline]##E##xpiring* button in the *_Pharmaceutical browsing_* window to produce the list of pharmaceuticals that are going to expire grouped by type and lot.
+Press the *[.underline]##E##xpiring* button in the *_Pharmaceutical browsing_* window to produce the list of pharmaceuticals that are going to expire grouped by type and lot.
 
+[#pharmaceutical-stock]
 === 6.2 Pharmaceutical Stock (Pharmaceutical [.underline]##S##tock)
 
 ==== 6.2.1 Main Characteristics
@@ -358,11 +409,11 @@ Press *[.underline]##E##xpiring* button in the *_Pharmaceutical browsing_* windo
 The Pharmaceutical Stock feature helps you to store and trace every stock movement that has been made. Every movement is identified by the following data:
 
 * date of the movement
-* type of the movement, that is, if it’s a charging or discharging one
-* the ward that the movement refers to. This characteristic is needed for discharging movements only. In fact, it’s important to know in which ward pharmaceuticals have been used, otherwise this field will appear empty
+* type of the movement, that is, if it is a charging or discharging one
+* the ward that the movement refers to. This characteristic is needed for discharging movements only. In fact, it is important to know in which ward pharmaceuticals have been used, otherwise this field will appear empty
 * the quantity
 * the pharmaceutical (which in turn relates to different categories: Laboratory, Surgery, Drugs or Chemical)
-* the lot which the movement is referred to. Actually, there are some pharmaceuticals that may not have a lot related (for example ‘Gloves’), so you can omit this field. But it’s recommended to store even the lot (if it exists), because every lot has its own peculiarity:
+* the lot which the movement is referred to. Actually, there are some pharmaceuticals that may not have a lot related (for example ‘Gloves’), so you can omit this field. But it is recommended to store even the lot (if it exists), because every lot has its own peculiarity:
 ** a name (that can be its code)
 ** a preparation date
 ** a due date
@@ -372,11 +423,11 @@ In this way you can find which movement refers to the pharmaceuticals that are e
 
 ==== 6.2.2 Functions of Pharmaceuticals Stock 
 
-To access the functions of Pharmaceuticals, press *Pharmaceutical [.underline]##S##tock* on the Pharmacy menu showed below.
+To access the functions of Pharmaceuticals, press *Pharmaceutical [.underline]##S##tock* on the Pharmacy menu shown below.
 
 image:image22.png[image,width=220,height=182]
 
-The window *_Stock movement browser_* showed below will be opened. All functions available under Pharmaceutical Stock are accessible from the *_Stock movement browser_* window.
+The window *_Stock movement browser_* shown below will be opened. All functions available under Pharmaceutical Stock are accessible from the *_Stock movement browser_* window.
 
 image:image23.png[image,width=598,height=327]
 
@@ -389,7 +440,7 @@ The following functions are available from the *Buttons Panel* of the window *_S
 * *Stock[.underline]##L##edger* to show the movements history for all pharmaceuticals (only dates range will be requested)
 * *[.underline]##C##lose* button, to exit from the *_Stock Movement Browser_* window
 
-As you can see, there’s no “Delete” button as you’re not allowed to delete a movement; but if a mistake occurs - for example you’ve inserted the wrong quantity of a pharmaceutical in charge – you must just insert the new movement to correct the mistake – a discharge movement in this example.
+As you can see, there’s no “Delete” button as you’re not allowed to delete a movement; but if a mistake occurs - for example you have inserted the wrong quantity of a pharmaceutical in charge – you must just insert the new movement to correct the mistake – a discharge movement in this example.
 
 Furthermore, a search function (*[.underline]##F##ilter)* is available using the Selection panel on the left of the window.
 
@@ -404,7 +455,7 @@ Using *_Stock Movement Browser_* search function, you can filter and show on the
 * in which ward a specific pharmaceutical has been discharged
 * if there are any pharmaceutical expired
 
-Queries about movements of pharmaceuticals can be done using the search criteria available on the *Selection panel* area of the *_Stock movement browser_* window (left side of the browser). Results of your search are showed on the *Data table* area.
+Queries about movements of pharmaceuticals can be done using the search criteria available on the *Selection panel* area of the *_Stock movement browser_* window (left side of the browser). Results of your search are shown on the *Data table* area.
 
 The selection panel is used to select a group of movements according to specific filters. You set a filter using the tools contained in the selection panel.
 
@@ -417,11 +468,12 @@ As far as a *Pharmaceutical* is concerned, user can choose its:
 
 In order to avoid conflicts, you can change one of these options only. So, when the description combo box is active, the other one is not, and vice versa.
 
-Since OpenHospital version 1.9, you can quickly find a medical you are looking for. Simply type a key word that is a part of its name into the text field at the top of the pharmaceuticals products combo box and press the search button (image:image81.png[zoom_r_button.png,width=15,height=15]) that follows this text field.
+Since Open Hospital version 1.9, you can quickly find a medical you are looking for. Simply type a key word that is a part of its name into the text field at the top of the pharmaceuticals products combo box and
+press the search button (image:image81.png[zoom_r_button.png,width=15,height=15]) that follows this text field.
 
 As far as *Movement* are concerned, user can choose its:
 
-* *_Type_*: it specifies if it’s a charge or a discharge one. If you select the discharge option, then the ward combo box gets enabled. The ward combo box allows you to find any discharging movements that refer to a specific ward.
+* *_Type_*: it specifies if it is a charge or a discharge one. If you select the discharge option, then the ward combo box gets enabled. The ward combo box allows you to find any discharging movements that refer to a specific ward.
 * *_Date_*: you can choose a time frame between ‘Date from’ and ‘Data to’. The date tools consist of three blank areas, which (from left to right) refer to day, month and year. As you have inserted a value on a blank area, he can move to the next one by typing the “Tab” button on the keyboard. As the window is loaded, the date is set in such a way to cover the last week by default.
 
 Finally, as far as *Lot preparation* and *Lot due date* you can search movements that refer to specific lots by inserting:
@@ -431,15 +483,15 @@ Finally, as far as *Lot preparation* and *Lot due date* you can search movements
 
 Each filter can be combined with another, allowing you to obtain many possibilities.
 
-After have chosen, press *[.underline]##F##ilter* button. The system will show on the *Data table* area results of the search applying criteria requested by you.
+After have chosen, press the *[.underline]##F##ilter* button. The system will show on the *Data table* area results of the search applying criteria requested by you.
 
 ===== 6.2.2.2 Insert stock charging movement ([.underline]##C##harge)
 
-To insert charging movements, you have to Press *[.underline]##C##harge* in the *_Stock movement browser_* window. The *_Stock movement_* window showed below appears. You can enter charge movements.
+To insert charging movements, you have to Press *[.underline]##C##harge* in the *_Stock movement browser_* window. The *_Stock movement_* window shown below appears. You can enter charge movements.
 
 image:image25.png[ChargingMvt.PNG,width=512,height=384]
 
-Since OpenHospital 1.8, you can perform more than one charging movement at a time. The window is composed with two areas: a *Panel* and a *Grid.*
+Since Open Hospital 1.8, you can perform more than one charging movement at a time. The window is composed with two areas: a *Panel* and a *Grid.*
 
 The panel contains following fields:
 
@@ -448,7 +500,8 @@ The panel contains following fields:
 * *Supplier*: origin of the pharmaceutical
 * *Reference No*: reference of the operation
 
-The Grid should be field with pharmaceutical involved in the charging movement. To field the Grid, you have to use the field above the grid to select pharmaceutical. Focus the field, enter the code or the description of the pharmaceutical and press *ENTER.* This will open the *_Choose a medical_* window.
+The Grid should be field with pharmaceutical involved in the charging movement. To field the Grid, you have to use the field above the grid to select pharmaceutical. Focus the field, enter the code or the description of the pharmaceutical and
+press *ENTER.* This will open the *_Choose a medical_* window.
 
 image:image26.png[medical selection.PNG,width=355,height=343]
 
@@ -456,7 +509,7 @@ Select the desired medical and click *[.underline]##Y##es*. This will open the *
 
 image:image27.png[quantityInput.PNG,width=310,height=135]
 
-Then press *Ok.* If there is existing lot in the system, the *_Existing lot_* window will appear.
+Then press *OK*. If there is existing lot in the system, the *_Existing lot_* window will appear.
 
 image:image28.png[Existing Lot Window.PNG,width=325,height=323]
 
@@ -468,25 +521,28 @@ If you want to use an existing Lot, you select the existing lot and click *Yes*.
 
 image:image29.png[lotInformations.PNG,width=422,height=158]
 
-Fill them and press *Ok*. The *_Input_* window will appear and you will fill the unit cost.
+Fill them and press *OK*. The *_Input_* window will appear and you will fill the unit cost.
 
 image:image30.png[UnitCost Input.PNG,width=310,height=137]
 
-Then click *Ok* to insert the medical line in the grid.
+Then click *OK* to insert the medical line in the grid.
 
-Click *Save* button to save the charge movement.
+Click the *Save* button to save the charge movement.
 
-NOTE: _The Lot definition can be set as automatic by changing the flag AUTOMATICLOT_IN in configuration file, so every new charging movement will automatically create a new lot; anyway, the Expiring Date must always be provided. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: The Lot definition can be set as automatic by changing the flag AUTOMATICLOT_IN in the configuration
+file, so every new charging movement will automatically create a new lot. Regardless of the setting
+the Expiring Date must always be provided. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
-NOTE: _You can avoid managing medicals cost by setting the LOTWITHCOST to no. Ask your Administrator how to do it or read the Administrator’s guide._
+NOTE: You can avoid managing the cost of medicals by setting the LOTWITHCOST to no. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
+[#insert-stock-discharging-movement]
 ===== 6.2.2.3 Insert stock discharging movement ([.underline]##D##ischarge)
 
-To insert charging movements, you have to Press *[.underline]##D##ischarge* in the *_Stock movement browser_* window. The *_Stock movement_* window showed below appears. You can enter charge movements.
+To insert charging movements, you have to Press *[.underline]##D##ischarge* in the *_Stock movement browser_* window. The *_Stock movement_* window shown below appears. You can enter charge movements.
 
 image:image31.png[ChargingMvt.PNG,width=463,height=347]
 
-Since OpenHospital 1.8, you can perform more than one discharging movement at a time. The window is composed with two areas: a *Panel* and a *Grid.*
+Since Open Hospital 1.8, you can perform more than one discharging movement at a time. The window is composed with two areas: a *Panel* and a *Grid.*
 
 The panel contains following fields:
 
@@ -495,7 +551,8 @@ The panel contains following fields:
 * *Destination*: Ward where the discharged medical will be affected.
 * *Reference No*: reference of the operation
 
-The Grid should be field with pharmaceuticals involved in the discharging movement. To field the Grid, you have to use the field above the grid to select pharmaceutical. Focus the field, enter the code or the description of the pharmaceutical and press *ENTER.* This will open the *_Choose a medical_* window.
+The Grid should be field with pharmaceuticals involved in the discharging movement. To field the Grid, you have to use the field above the grid to select pharmaceutical. Focus the field, enter the code or the description of the pharmaceutical and
+press *ENTER.* This will open the *_Choose a medical_* window.
 
 image:image26.png[medical selection.PNG,width=423,height=409]
 
@@ -503,37 +560,42 @@ Select the desired medical and click *[.underline]##Y##es*. This will open the *
 
 image:image32.png[quantityInput.PNG,width=268,height=135]
 
-Then press *Ok.* The *_Lot information_* window will appear.
+Then press *OK*. The *_Lot information_* window will appear.
 
 image:image33.png[Existing Lot Window.PNG,width=379,height=378]
 
-You select the existing lot and click *Yes*. Then click *Ok* to insert the medical line in the grid.
+You select the existing lot and click *Yes*. Then click *OK* to insert the medical line in the grid.
 
-Click *Save* button to save the discharge movement.
+Click the *Save* button to save the discharge movement.
 
-NOTE: _The Lot definition can be set as automatic by changing the flag AUTOMATICLOT_OUT in configuration file, so every new discharging movement will automatically select a suitable lot for the operation according to the expiring date. If the first selected lot is does not contain enough quantity to serve the discharging movement, several discharging movements may be generated. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: The Lot definition can be set as automatic by changing the flag AUTOMATICLOT_OUT in the configuration
+file, so every new discharging movement will automatically select a suitable lot for the operation according
+to the expiring date. If the first selected lot does not contain enough quantity to serve the discharging
+movement, several discharging movements may be generated. Ask your Administrator or read the _Administrator’s Guide_
+for more information.
 
 <<<
 
+[#pharmaceutical-stock-ward]
 === 6.3 Pharmaceuticals Stock Ward (Pharmaceuticals Stock [.underline]##W##ard)
 
 ==== 6.3.1 Main Characteristics
 
 The Pharmaceutical Stock Ward feature allows the management of the pharmacy at ward level.
 
-*Pharmaceuticals Stock [.underline]##W##ard* functionality can be enabled or disabled by changing the _INTERNALPHARMACIES_ flag in the configuration file**.** Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+*Pharmaceuticals Stock [.underline]##W##ard* functionality can be enabled or disabled by changing the _INTERNALPHARMACIES_ flag in the configuration file**.** Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 image:image22.png[image,width=220,height=182]
 
 ==== 6.3.2 Functions of Pharmaceuticals Stock Ward 
 
-To access the functions of Pharmaceuticals, press *Pharmaceutical Stock [.underline]##W##ard* on the Pharmacy menu showed below.
+To access the functions of Pharmaceuticals, press *Pharmaceutical Stock [.underline]##W##ard* on the Pharmacy menu shown below.
 
-The window *_Ward pharmacy_* showed below will be opened. All functions available under Pharmaceutical Stock are accessible from the *_Ward pharmacy_* window selecting one *WARD* on the top left of the window.
+The window *_Ward pharmacy_* shown below will be opened. All functions available under Pharmaceutical Stock are accessible from the *_Ward pharmacy_* window selecting one *WARD* on the top left of the window.
 
 image:image34.png[image,width=616,height=347]
 
-After the selection of the ward (INTERNAL MEDICINE in the example) the *_Ward pharmacy_* window appears as showed below and you can start the management of the ward pharmacy of the INTERNAL MEDICINE ward.
+After the selection of the ward (INTERNAL MEDICINE in the example) the *_Ward pharmacy_* window appears as shown below and you can start the management of the ward pharmacy of the INTERNAL MEDICINE ward.
 
 image:image35.png[image,width=614,height=346]
 
@@ -545,13 +607,14 @@ These functionalities are available in the window
 * *[.underline]##E##xcel*: Export data to Excel
 * *Stoc[.underline]##k## Card* to show the movements history for a certain pharmaceutical (can be directly selected by the list otherwise will be requested)
 
-Differently by *Pharmaceuticals [.underline]##S##tock* functionality, the *Pharmaceutical Stock [.underline]##W##ard* allows an only discharging movement to patients since is an internal management of pharmaceuticals lying in the wards after they have been “charged” by the main pharmacy. But since OpenHospital 1.9, discharging movement from ward to ward is also possible.
+Differently by *Pharmaceuticals [.underline]##S##tock* functionality, the *Pharmaceutical Stock [.underline]##W##ard* allows an only discharging movement to patients since is an internal management of pharmaceuticals lying in the wards after they have been “charged” by the main pharmacy. But since Open Hospital 1.9, discharging movement from ward to ward is also possible.
 
 The *_Ward Pharmacy_* window will show a *Filter Panel* on the left, a *Movements Panel* in the right-centre and a *Button Panel* at the bottom.
 
 ===== 6.3.2.1 Rectify (Rectify)
 
-Since OpenHospital 1.8, it is possible to rectify the quantity lying in stock in the Ward Pharmacy. This can be necessary when a drug is damaged or stolen. To do this, click the Rectify button to open the Rectify window.
+Since Open Hospital 1.8, it is possible to rectify the quantity lying in stock in the Ward Pharmacy. This can be necessary when a drug is damaged or stolen. To do this, 
+click the Rectify button to open the Rectify window.
 
 image:image36.png[Rectify.PNG,width=576,height=224]
 
@@ -560,12 +623,13 @@ image:image36.png[Rectify.PNG,width=576,height=224]
 * Modify the *actual quantity*
 * Enter the reason of the rectification
 
-NOTE: _Since v1.11.0 lot management is compulsory when rectifying quantities in wards._
+NOTE: Since version 1.11.0 lot management is compulsory when rectifying quantities in wards.
 
 image:image37.png[Rectify filled.PNG,width=574,height=224]
 
-Click *Ok* to save the rectification or Cancel to abort.
+Click *OK* to save the rectification or *Cancel* to abort.
 
+[#search-ward-pharmacy-movements]
 ===== 6.3.2.2 Search Ward Pharmacy movements ([.underline]##F##ilter)
 
 image:image38.png[WardPharmacy_filter.PNG,width=173,height=259]
@@ -590,12 +654,12 @@ The Movements Panel is made by three tabs:
 ** *Patient:* the patient the movement is related to, with his/her age, sex and weight (ND if the weight has not been defined at the registration moment)
 ** *Medical*: the drug subject of the movement
 ** *Quantity*: the quantity subject of the movement
-* *Incomes*: shows all incomings from the main pharmacy, it’s to say all discharging movements registered in *_Pharmaceutical Stock_* window related to selected ward
+* *Incomes*: shows all incomings from the main pharmacy, it is to say all discharging movements registered in *_Pharmaceutical Stock_* window related to selected ward
 * *Drugs*: the number of drugs remaining in the selected ward as a result of all incoming minus all out comings.
 
 ===== 6.3.2.4 Inserting a new Ward Pharmacy Movement ([.underline]##N##ew)
 
-To insert ward pharmacy movements, you have to press [.underline]##N##ew in the *_Ward Pharmacy_* window. The *_New / Edit_* window showed below appears.
+To insert ward pharmacy movements, you have to press [.underline]##N##ew in the *_Ward Pharmacy_* window. The *_New / Edit_* window shown below appears.
 
 image:image39.png[WardPharmacy_new.PNG,width=456,height=424]
 
@@ -606,14 +670,20 @@ As told before, only discharging movements are allowed in this functionality. So
 
 image:image40.png[WardPharmacy_medical.PNG,width=273,height=129]image:image41.png[WardPharmacy_quantity.PNG,width=231,height=139]
 
-If _AUTOMATICLOTWARD_TOWARD_ has been enabled the user will be requested to select a lot (similarly to link:#6223-insert-stock-discharging-movement-discharge[6.2.2.3 Insert Stock Discharging Movement])
+If _AUTOMATICLOTWARD_TOWARD_ has been enabled the user will be requested to select a lot (similar to
+<<#insert-stock-discharging-movement,Insert Stock Discharging Movement>>).
 
-NOTE: _The Lot selection can be enabled or disabled (set as automatic) by changing the flag AUTOMATICLOTWARD_TOWARD in configuration file, so every new discharging movement will automatically select a suitable lot for the operation according to the expiring date (FEFO). If the first selected lot is does not contain enough quantity to serve the discharging movement, several discharging movements may be generated if  the quantity laying in other lots can suite the request. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: The Lot selection can be enabled or disabled (set as automatic) by changing the flag AUTOMATICLOTWARD_TOWARD in
+the configuration file, so every new discharging movement will automatically select a suitable lot for the
+operation according to the expiring date (FEFO). If the first selected lot does not contain enough quantity
+to serve the discharging movement, several discharging movements may be generated if the quantity laying in
+other lots can suite the request. Ask your Administrator read the _Administrator’s Guide_ for more information.
 
 Before to press the *[.underline]##O##K* button, you may insert as many Medicals you need, it will show a correspondent number of movements in the *Outcomes* tab of the *Movement Panel* in the *_Ward Pharmacy_* window. These movements will also be visible in the *Incomes* tab of the *Movement Panel* in the *_Ward Pharmacy_* window of the receiving ward, in case of discharging to another ward.
 
 <<<
 
+[#laboratory]
 == 7 Laboratory ([.underline]##L##aboratory)
 
 === 7.1 Main Characteristics 
@@ -621,7 +691,7 @@ Before to press the *[.underline]##O##K* button, you may insert as many Medicals
 With Laboratory’s features the user can manage the laboratory exams.
 
 .Press *[.underline]##L##aboratory* button or “Alt + L”.
-[#7-default-main-menu]
+[#default-main-menu-7]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
@@ -633,9 +703,9 @@ It is possible to create, modify or delete exams.
 
 === 7.2 Functions of Laboratory
 
-*_To access the Laboratory’s functions press_ [.underline]##L##aboratory* *_on the main menu of OpenHospital. The Laboratory browsing_* window appears.
+*_To access the Laboratory’s functions press_ [.underline]##L##aboratory* *_on the main menu of Open Hospital. The Laboratory browsing_* window appears.
 
-All functions available under *[.underline]##L##aboratory* are accessible from the *_Laboratory browsing_* window showed below. By default, the system shows all the laboratory exams recorded.
+All functions available under *[.underline]##L##aboratory* are accessible from the *_Laboratory browsing_* window shown below. By default, the system shows all the laboratory exams recorded.
 
 image:image43.png[image,width=528,height=339]
 
@@ -651,8 +721,8 @@ To access the other functions of laboratory in the *Buttons Panel* you have the 
 * *[.underline]##E##dit* to modify an existing laboratory exam
 * *[.underline]##D##elete*, to delete an existing laboratory exam
 * *[.underline]##C##lose* to close the window and return to the Menu
-* *[.underline]##P##rint table* to print the list of laboratory exams showed in the table
-* *[.underline]##P##rint label* to print the samples lables for laboratory exams
+* *[.underline]##P##rint table* to print the list of laboratory exams shown in the table
+* *[.underline]##P##rint label* to print the samples labels for laboratory exams
 
 Furthermore, a search function (*[.underline]##S##earch)* is available using the Selection panel on the left of the window.
 
@@ -660,7 +730,7 @@ Furthermore, a search function (*[.underline]##S##earch)* is available using the
 
 Search function allows you to select and show laboratory exams on the *Data table* of the *_Laboratory browsing_* window.
 
-In the example hereinafter, all types of exams executed in date 02.11.2006 are showed in *Data table*.
+In the example hereinafter, all types of exams executed in date 02.11.2006 are shown in *Data table*.
 
 image:image43b.png[image,width=528,height=339]
 
@@ -669,18 +739,19 @@ Data about exams can be selected by choosing specific fields among the following
 * *Select an exam:* Values admitted are:
 
 ____
-ALL, exams of all types are showed
+ALL, exams of all types are shown
 
-Single exam, only the exams of the selected type are showed
+Single exam, only the exams of the selected type are shown
 ____
 
 * **Date: “**Date From” and “Date To” allow the selection of all the exam executed in the requested period
 
-After the selection press *[.underline]##S##earch* button; the system will show on the table results of the search applying the criteria requested.
+After the selection press the *[.underline]##S##earch* button; the system will show on the table results of the search applying the criteria requested.
 
+[#create-a-new-laboratory-exam]
 ==== 7.2.2 Create a new laboratory exam ([.underline]##N##ew)
 
-Press *[.underline]##N##ew* button in the *_Laboratory browsing_* window: The *_New Laboratory exam_* window showed below appears:
+Press the *[.underline]##N##ew* button in the *_Laboratory browsing_* window: The *_New Laboratory exam_* window shown below appears:
 
 image:image44.png[image,width=395,height=433]
 
@@ -699,7 +770,7 @@ To record the visit, enter the following fields:
 
 ===== 7.2.2.1 Results
 
-In OpenHospital you have basically two kind of possible results for each exam:
+In Open Hospital you have basically two kind of possible results for each exam:
 
 * *Single Result*: where you can select only one result among a list (Procedure 1)
 * *Multiple Results*: where you may specify many results among a list of positive/negative values (Procedure 2)
@@ -707,29 +778,32 @@ In OpenHospital you have basically two kind of possible results for each exam:
 
 image:image45.png[Laboratory_new_proc1.PNG,width=309,height=340]image:image46.png[Laboratory_new_proc2.PNG,width=309,height=340]image:image46b.png[Laboratory_new_proc3.PNG,width=309,height=340]
 
-NOTE: _Exams, Exam Types and Results as well, can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: Exams, Exam Types and Results as well, can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm and record data
+* *[.underline]##O##K* to confirm and record data
 * *[.underline]##C##ancel* to close the window and return to the Menu without record data
 * *[.underline]##P##rint* to print the result
 
 ==== 7.2.3 Modify a laboratory exam ([.underline]##E##dit)
 
-To modify an exam, you have to highlight it first in the *_Laboratory browsing_* window. Once highlighted, press *[.underline]##E##dit* button to enter the *_Edit Laboratory_* exam window showed below. Now the record is available for changes. With this function you can modify all data of the exam and you can input the result of the exam too.
+To modify an exam, you have to highlight it first in the *_Laboratory browsing_* window. Once highlighted,
+press the *[.underline]##E##dit* button to enter the *_Edit Laboratory_* exam window shown below. Now the record is available for changes. With this function you can modify all data of the exam and you can input the result of the exam too.
 
 image:image47.png[image,width=394,height=432]
 
 ==== 7.2.4 Delete Laboratory Exam ([.underline]##D##elete)
 
-To delete an exam, you have to highlight it first in the *_Laboratory browsing_* window. Once highlighted, press *[.underline]##D##elete* button to see the confirmation window showed below.
+To delete an exam, you have to highlight it first in the *_Laboratory browsing_* window. Once highlighted,
+press the *[.underline]##D##elete* button to see the confirmation window shown below.
 
 image:image48.png[image,width=240,height=174]
 
 === 7.3 Laboratory Extended (v.1.1)
 
-Since OpenHospital version 1.3.1 you can extend the _New Laboratory_ functionality by change the _LABEXTENDED_ flag in the configuration file. Ask to your Administrator how to do it.
+Since Open Hospital version 1.3.1 you can extend the _New Laboratory_ functionality by change the _LABEXTENDED_ flag in the configuration file. Ask your Administrator how to do it.
 
 ==== 7.3.1 New Laboratory Browsing (v 1.1)
 
@@ -741,11 +815,11 @@ The only difference is the new column about the name of the patient because it i
 
 ==== 7.3.2 New Laboratory Exam (v. 2.0)
 
-The new *_Laboratory Exam_* window is now strictly related to the patient, it’s to say that the exam must be assigned to a patient previously registered in the DB.
+The new *_Laboratory Exam_* window is now strictly related to the patient, it is to say that the exam must be assigned to a patient previously registered in the DB.
 
 Before to close the window with the exam result you must have selected a patient from the list; the fields below will give you a slight patient details summary.
 
-A search field can be used to fast search the patient by typing part of his/her name or his/her OpenHospital code (which is specified in the Patient window, see *_Patient Extended_*).
+A search field can be used to fast search the patient by typing part of his/her name or his/her Open Hospital code (which is specified in the Patient window, see *_Patient Extended_*).
 
 The New Laboratory Exam window (thus the Edit one) will appear like the following:
 
@@ -753,15 +827,16 @@ image:image50.png[image,width=531,height=530]
 
 The *Patient’s data panel* cannot be modified except *Note Field* and only shows the information related to the selected Patient.
 
+[#laboratory-multiple-insert]
 ==== 7.3.3 Laboratory Multiple Insert
 
-Since OpenHospital version 1.4.1 you can extend the _New Laboratory_ functionality by change the _LABMULTIPLEINSERT_ flag in the configuration file. The flag _LABEXTENDED_ have to be enabled too. Ask to your Administrator how to do it.
+Since Open Hospital version 1.4.1 you can extend the _New Laboratory_ functionality by change the _LABMULTIPLEINSERT_ flag in the configuration file. The flag _LABEXTENDED_ have to be enabled too. Ask your Administrator how to do it.
 
 The New Laboratory Multiple allows multiple exam insertion for each patient, avoiding repeating the new laboratory exam procedure (*[.underline]##N##ew*) for every exam for the same patient.
 
 ===== 7.3.3.1 New Patient Exam ([.underline]##N##ew)
 
-Press *[.underline]##N##ew* button in the *_Laboratory browsing_* window: The *_New Patient exam_* window showed below appears.
+Press the *[.underline]##N##ew* button in the *_Laboratory browsing_* window: The *_New Patient exam_* window shown below appears.
 
 image:image51.png[Laboratory_Multiple_new.PNG,width=437,height=414]
 
@@ -770,10 +845,11 @@ To record the visit, enter the following fields:
 * *Data*: date of the exam, the application propose the current date
 * *Patient*: select a patient by pressing the *Find [.underline]##P##atient* button
 * *OPD/IPD*: the window automatically will check if the patient is admitted or not in the hospital; anyway, is possible to change it if needed
-* *[.underline]##E##xam*: choose the exam; a first window will ask you the material, then a second one the exam, finally a third one will ask you the result if the exam allows only a single result, otherwise the list of multiple results will be showed in the right panel, together with the chosen material.
+* *[.underline]##E##xam*: choose the exam; a first window will ask you the material, then a second one the exam, finally a third one will ask you the result if the exam allows only a single result, otherwise the list of multiple results will be shown in the right panel, together with the chosen material.
 * *Note*: exam reporting (different for each exam)
 
-NOTE: _At any time, before to press OK, you can modify every exam by clicking it on the list and changing material, results and note in the relative panels._
+NOTE: At any time, before pressing *OK*, you can modify every exam by clicking it on the list and changing material,
+results and notes in the relative panels.
 
 <<<
 
@@ -781,11 +857,11 @@ NOTE: _At any time, before to press OK, you can modify every exam by clicking it
 
 === 8.1 Main Characteristics
 
-Accounting is the function that you have to use to manage the billing process. You can enter the bill of pharmaceuticals, operations, exams or other costs of a patient. For the time being the billing process is not linked with other functions of *OpenHospital* and therefore the application does not propose the billing item based on the therapy followed by the patient: [.underline]#the user has to input all the items.#
+Accounting is the function that you have to use to manage the billing process. You can enter the bill of pharmaceuticals, operations, exams or other costs of a patient. For the time being the billing process is not linked with other functions of *Open Hospital* and therefore the application does not propose the billing item based on the therapy followed by the patient: [.underline]#the user has to input all the items.#
 
 Accounting function furthermore allows to manage the payment of bills (total or partial) and to produce reports.
 
-.Press *A[.underline]##c##counting* button or “Alt + C” to open the Accounting Sub-Menu
+.Press the *A[.underline]##c##counting* button or “Alt + C” to open the Accounting Sub-Menu
 [frame=none]
 [grid=none]
 [caption="Sub Menu: "]
@@ -795,7 +871,8 @@ Accounting function furthermore allows to manage the payment of bills (total or 
 
 === 8.2 Functions of Accounting
 
-All functions available under *A[.underline]##c##counting* are accessible from the *_Patients Bills Management_* window showed below. To access the *_Patients bills Management_* window press *[.underline]##B##ills Manager* on the *_Accounting_* menu.
+All functions available under *A[.underline]##c##counting* are accessible from the *_Patients Bills Management_* window shown below. To access the *_Patients bills Management_* window
+press *[.underline]##B##ills Manager* on the *_Accounting_* menu.
 
 By default, the window shows in the *Data table* all the bills of today (current day).
 
@@ -827,9 +904,11 @@ Furthermore, the *_Patients Bills Management_* window shows an *Incomes Table* w
 * *First Row*: the *PAID* and *UNPAID* within *Today*
 * *Second Row*: the *PAID* and *UNPAID* within the visualized *Period*
 
+[#insert-a-new-bill]
 ==== 8.2.1 Insert a new bill ([.underline]##N##ew Bill)
 
-You can use the *New Patient Bill* function to register a new bill of a patient. Press *[.underline]##N##ew Bill* button in the *_Patients Bills Management_* window to access the *_New Patient Bill_* window showed below.
+You can use the *New Patient Bill* function to register a new bill of a patient.
+Press the *[.underline]##N##ew Bill* button in the *_Patients Bills Management_* window to access the *_New Patient Bill_* window shown below.
 
 The bill is not saved until you do not confirm it with the *[.underline]##S##AVE* function (see description below).
 
@@ -839,22 +918,24 @@ The *_New Patient Bill_* window is composed by three areas: the *Bill Panel* on 
 
 Bills are composed by items. A bill item is a cost related to either a pharmaceutical or an operation or an exam or others/custom costs.
 
-Data showed on the *Bill Panel* area are:
+Data shown on the *Bill Panel* area are:
 
 * *Date*: it is the date and time of the bill
 * *Patient*: it is the patient associated with the bill
 * *List*: it is the PriceList that will be used for this bill +
  +
-NOTE: _PriceLists can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: PriceLists can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
-Data showed on the *Item Panel* area are:
+Data shown on the *Item Panel* area are:
 
 * *Item, Qty, Amount*: they are the description of the bill entry, the selected quantity and the amount; the amount is calculated as the unitary cost of the item multiplied by the quantity;
 * *TOTAL*: it is the total amount of the bill +
  +
-NOTE: _Prices, or unitary costs, can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: Prices, or unitary costs, can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document._
 
-Data showed on *The Payments* area are:
+Data shown on *The Payments* area are:
 
 * *Date*: it is the date and time of the payment
 * *Amount*: it is the amount of the payment
@@ -864,11 +945,13 @@ image:image54.png[image,width=484,height=418]
 
 To insert a new bill first of all you have to enter the *Date field*. The application proposes you the current date and time but you can modify both of them.
 
-Then you have to select a patient. To do it, press the *find [.underline]##P##atient* button on top of the screen. The *_Patient Selection_* window showed below appears.
+Then you have to select a patient. To do it, press the *find [.underline]##P##atient* button on top of the screen. The *_Patient Selection_* window shown below appears.
 
 Once you have selected the patient you can start to enter bill entries of the bill.
 
-NOTE: _A patient can have severals pending bills if only if the the parameter ALLOWMULTIPLEOPENEDBILL is enabled (see the administrator manual). Else If the patient has a pending bill associated it will be recalled to edit it. You cannot start a new bill for a patient before to close the previous one._
+NOTE: A patient can have several pending bills only if the parameter ALLOWMULTIPLEOPENEDBILL is enabled
+(see the Administrator Manual). Otherwise if the patient has a pending bill, the bill will be recalled to
+edit it. You cannot start a new bill for a patient before closing the previous one.
 
 There are several types of Bill entry. They are identified by the button on the *Buttons panel* on the right of the window; you have the following choices:
 
@@ -878,7 +961,8 @@ There are several types of Bill entry. They are identified by the button on the 
 * *[.underline]##O##ther* to enter other prices defined in the PriceList
 * *[.underline]##C##ustom* to enter custom items defined on the fly
 
-NOTE: _Types can be defined by the Administrator. Ask to your Administrator how to do it or read the see link:#14-general-data-general-data[General Data] in this document._
+NOTE: Types can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
 
 ===== 8.2.1.1 Insert a bill entry related to Medicals, Operations or Exams ([.underline]##M##edical, [.underline]##O##peration, [.underline]##E##xam) 
@@ -887,7 +971,7 @@ We show here how to insert an bill entry for pharmaceutical (*[.underline]##M##e
 
 image:image55.png[image,width=543,height=563]
 
-To insert a bill entry, press the *[.underline]##M##edical* button. The *_Medical_* window showed below appears.
+To insert a bill entry, press the *[.underline]##M##edical* button. The *_Medical_* window shown below appears.
 
 image:image56.png[image,width=410,height=297]
 
@@ -895,21 +979,21 @@ Using the mouse, you have to highlight the required pharmaceutical (medical).
 
 On the *Buttons Panel* of the *_Medical_* window you have the following choices:
 
-* *[.underline]##O##k* to select the highlighted pharmaceutical
+* *[.underline]##O##K* to select the highlighted pharmaceutical
 * *[.underline]##C##ancel* to return to the *_New patient Bill_* window without selecting any pharmaceutical
 
-If you choose *[.underline]##O##K* the *_Quantity_* window showed below appears and you can select the quantity of pharmaceutical used by the patient.
+If you choose *[.underline]##O##K* the *_Quantity_* window shown below appears and you can select the quantity of pharmaceutical used by the patient.
 
 image:image57.png[image,width=307,height=134]
 
 On the *Buttons Panel* of the *_Quantity_* window you have the following choices:
 
-* *[.underline]##O##k* to select the highlighted pharmaceutical and return to the *_New patient Bill_* window
+* *[.underline]##O##K* to select the highlighted pharmaceutical and return to the *_New patient Bill_* window
 * *[.underline]##C##ancel* to return to the *_New patient Bill_* window without selecting any pharmaceutical
 
 ===== 8.2.1.2 Insert a bill entry related to various custom reasons (C[.underline]##u##stom) 
 
-To insert a custom bill entry, you have to press the *C[.underline]##u##stom* button. The application will show the *_Custom item_* window showed below.
+To insert a custom bill entry, you have to press the *C[.underline]##u##stom* button. The application will show the *_Custom item_* window shown below.
 
 image:image58.png[image,width=307,height=134]
 
@@ -917,7 +1001,7 @@ In this window you have to enter a description (in the example below is “numbe
 
 On the *Buttons Panel* of the *_Custom item_* window you have the following choices:
 
-* *[.underline]##O##k* to go to another *_Custom item_* window (to enter the quantity, see below)
+* *[.underline]##O##K* to go to another *_Custom item_* window (to enter the quantity, see below)
 * *[.underline]##C##ancel* to return to the *_New patient Bill_* window without insert any bill entry
 
 image:image59.png[image,width=307,height=134]
@@ -926,16 +1010,17 @@ In the *_Custom item_* window, you have to enter the amount related to the bill 
 
 On the *Buttons Panel* of the *_Custom item_* window you have the following choices:
 
-* *[.underline]##O##k* to confirm the bill entry and return in the *_New patient Bill_* window
+* *[.underline]##O##K* to confirm the bill entry and return in the *_New patient Bill_* window
 * *[.underline]##C##ancel* to return to th**e _New patient Bill_** window without insert any bill entry
 
 ===== 8.2.1.3 Remove a bill entry of a bill (Remove Item) 
 
-First of all, to remove a bill entry you have to highlight it on the *_New Patient Bill_* window. Once you’ve done this, (pay attention!) pressing the *Remove Item* button, the bill entry is removed. Bill entries can be removed before or after the final saving (see *Save function* described below)
+First of all, to remove a bill entry you have to highlight it on the *_New Patient Bill_* window. Once you have done this, (pay attention!) pressing the *Remove Item* button, the bill entry is removed. Bill entries can be removed before or after the final saving (see
+<<save-function-accounting,Save function>> described below).
 
 ===== 8.2.1.4 Insert a payment (Pa[.underline]##y##ment)
 
-To insert a payment, you have to press the *Pa[.underline]##y##ment* button. The application will show the *_Quantity_* window showed below.
+To insert a payment, you have to press the *Pa[.underline]##y##ment* button. The application will show the *_Quantity_* window shown below.
 
 image:image60.png[image,width=307,height=134]
 
@@ -943,7 +1028,7 @@ You have to insert the amount of the payment. (in the example above is “12” 
 
 On the *Buttons Panel* of the *_Quantity_* window you have the following choices:
 
-* *[.underline]##O##k* to confirm the payment and return to the *_New patient Bill_* window
+* *[.underline]##O##K* to confirm the payment and return to the *_New patient Bill_* window
 * *[.underline]##C##ancel* to return to the *_New patient Bill_* window without insert any payment
 
 ===== 8.2.1.5 Insert a refund (Refund)
@@ -952,16 +1037,18 @@ Sometimes it happens that the cashier has to refund the patient; in this case yo
 
 ===== 8.2.1.6 Payment receipt
 
-Since OpenHospital version 1.8 you can print the Payment receipt any time, once you have made a payment. Click *Payment receipt* button.
+Since Open Hospital version 1.8 you can print the Payment receipt any time, once you have made a payment.
+Click the *Payment receipt* button.
 
 ===== 8.2.1.7 Remove a payment (Remove Payment) 
 
-First of all, to remove a payment you have to highlight it on the *_New Patient Bill_* window. Once you’ve done this, (pay attention!) pressing the *Remove Payment* button, the payment is removed.
+First of all, to remove a payment you have to highlight it on the *_New Patient Bill_* window. Once you have done this, (pay attention!) pressing the *Remove Payment* button, the payment is removed.
 
 ===== 8.2.1.8 Give change… (Give change…) 
 
 Sometimes it could be useful to calculate the balance to give to a patient when he/she is paying his/her bill. By pressing on *Give change...* button you will be asked the cash amount the patient is giving and automatically you will know the amount to give to him/her calculated as a difference between the patient cash and the current bill balance.
 
+[#save-function-accounting]
 ===== 8.2.1.9 Save function ([.underline]##S##AVE)
 
 When you have completed the input of data (bill or payments) press the *[.underline]##S##AVE* button on the button panel of the *_New Patient Bill_*.
@@ -974,35 +1061,39 @@ If the patient is going to pay his/her bill totally you can press the *P[.underl
 
 ===== 8.1.2.11 Print receipt function
 
-Since OpenHospital version 1.7 you can print on the fly a receipt when you press the *P[.underline]##a##id* button__. To enable this feature, you must enable the RECEIPTPRINTER__ flag in the configuration file and a proper device must be connected to the system. Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+Since Open Hospital version 1.7 you can print on the fly a receipt when you press the *P[.underline]##a##id* button__. To enable this feature, you must enable the RECEIPTPRINTER__ flag in the configuration file and a proper device must be connected to the system. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 ===== 8.2.1.12 Close function ([.underline]##C##lose)
 
-Close function allows you to exit from the *_New Patient Bill_* window without saving changes done**_._** Press the *[.underline]##C##lose* button to access the Close function. The confirmation window showed below appears.
+The close function allows you to optionally exit from the *_New Patient Bill_* window without saving changes.
+Press the *[.underline]##C##lose* button to access the Close function. The confirmation window shown below appears.
 
 image:image61.png[image,width=278,height=130]
 
 ==== 8.2.2 Edit an existing bill ([.underline]##E##dit Bill)
 
-First of all, to modify an existing bill you have to highlight it in the *_Patients Bills Management_* window. Once you’ve done this, press the *[.underline]##E##dit Bill* button. The *_New Patient Bill_* window will appear.
+First of all, to modify an existing bill you have to highlight it in the *_Patients Bills Management_* window. Once you have done this, 
+press the *[.underline]##E##dit Bill* button. The *_New Patient Bill_* window will appear.
 
-NOTE: _Only bills with status “O” (Open) can be modified, otherwise an A4 report will be shown._
+NOTE: Only bills with status “O” (Open) can be modified, otherwise an A4 report will be shown.
 
 ==== 8.2.3 Delete a bill ([.underline]##D##elete Bill)
 
-First of all, to delete an existing bill you have to highlight it in the *_Patients Bills Management_* window. Once you’ve done this, press the *[.underline]##D##elete Bill* button. The *_Delete_* window will appear.
+First of all, to delete an existing bill you have to highlight it in the *_Patients Bills Management_* window. Once you have done this, 
+press the *[.underline]##D##elete Bill* button. The *_Delete_* window will appear.
 
 image:image62.png[Accounting_delete.PNG,width=328,height=118]
 
-NOTE: _Generally, this is not allowed to regular users and should be performed only by the Administrator._
+NOTE: Generally this is not allowed for regular users and should be performed only by the Administrator.
 
 ==== 8.2.4 Receipt (Receipt)
 
-Since OpenHospital version 1.8 you can print the bill receipt direct from the *_Bill manager_* window. Highlight the bill and click *[.underline]##R##eceipt* button. A proper device must be connected to the system.
+Since Open Hospital version 1.8 you can print the bill receipt direct from the *_Bill manager_* window. Highlight the bill 
+and click the *[.underline]##R##eceipt* button. A proper device must be connected to the system.
 
 ==== 8.2.5 Reports (Report)
 
-OpenHospital Accounting module comes with a set of reports hereby listed:
+Open Hospital Accounting module comes with a set of reports hereby listed:
 
 * *Today (Closure)*: report that show the current user incomes
 * *Today*: report that show a statement with all paid and unpaid bills within today
@@ -1024,11 +1115,11 @@ Once the choice has been done, after some instants the JasperViewer® will show 
 
 image:image65.png[Accounting_report_pdf.PNG,width=642,height=470]
 
-NOTE: _By default, an internal PDF viewer is used. You can use an external PDF reader by modifying the INTERNALVIEWER flag in the configuration file. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: By default, an internal PDF viewer is used. You can use an external PDF reader by modifying the INTERNALVIEWER flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 You can save the report as PDF by clicking on save button (image:image66.png[Report_save.PNG,width=21,height=19]) or printing it by clicking on print button (image:image67.png[Report_print.PNG,width=21,height=18]).
 
-NOTE: _A PDF copy of every report is always saved within the folders of OpenHospital. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: A PDF copy of every report is always saved within the folders of Open Hospital. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 === 8.3 Functions of Accounting in multi-user mode
 
@@ -1042,12 +1133,13 @@ So, the *Incomes Table* will show follow information:
 * *Second Row*: the *PAID* and *UNPAID* within the visualized *Period*
 * *Third Row*: the *PAID* and *UNPAID* for the current *user* within *Today*
 
-While the admin user will be able to filter all incomes among all users that have been involved in some payments:
+While the Administrator user will be able to filter all incomes among all users that have been involved in some payments:
 
 image:image69.png[../../Screen%20Shot%202019-07-26%20at%2015.35.27.png,width=521,height=334]
 
 <<<
 
+[#vaccines]
 == 9 Vaccines (Patient [.underline]##V##accines)
 
 === 9.1 Main Characteristics
@@ -1055,13 +1147,13 @@ image:image69.png[../../Screen%20Shot%202019-07-26%20at%2015.35.27.png,width=521
 Vaccines functionality allows managing vaccines for all the patients registered. It is possible to register vaccinations, modify or delete them. A specific search function is also available.
 
 .Click with the mouse on the button or press "Alt + V" to enter the *Patient Vaccines browsing* window
-[#9-default-main-menu]
+[#default-main-menu-9]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
 === 9.2 Functions of Admission/Patients
 
-All functions available under *Patient [.underline]##V##accines* are accessible from the window *_Patient vaccines browsing_* window showed below.
+All functions available under *Patient [.underline]##V##accines* are accessible from the window *_Patient vaccines browsing_* window shown below.
 
 By default, the window shows in *Data table* all the vaccinations currently present in the system.
 
@@ -1078,7 +1170,7 @@ Furthermore, a search function is available using the *Selection panel* on the l
 
 ==== 9.2.1 Search vaccinations 
 
-Queries about vaccinations can be done using the search criteria available on the *Selection panel* area of the window (left side of the window). Results of your search are showed on the *Data table* area.
+Queries about vaccinations can be done using the search criteria available on the *Selection panel* area of the window (left side of the window). Results of your search are shown on the *Data table* area.
 
 Doing the selection, data about vaccinations can be selected by choosing specific fields among the following ones:
 
@@ -1088,11 +1180,12 @@ Doing the selection, data about vaccinations can be selected by choosing specifi
 * **Age. “**Age From” and “Age To” allow the selection of all the patients subject to vaccinations by age
 * *Sex.* All / Male / Female
 
-NOTE: _VaccineTypes and Vaccines can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: VaccineTypes and Vaccines can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
-After the selection press *[.underline]##S##earch* button; the system will show on *Data table* results of the search applying the criteria requested.
+After the selection press the *[.underline]##S##earch* button; the system will show on *Data table* results of the search applying the criteria requested.
 
-The function shows in the field “Count:” the number of vaccinations that are showed in *Data Table* (in the example they are 3).
+The function shows in the field “Count:” the number of vaccinations that are shown in *Data Table* (in the example they are 3).
 
 image:image72.png[image,width=619,height=245]
 
@@ -1100,7 +1193,7 @@ image:image72.png[image,width=619,height=245]
 
 You can use this function to register a new Patient vaccination when executed.
 
-Press *[.underline]##N##ew* button in the *_Patient vaccines browsing_* window to access the *_New patient vaccine_* window showed below.
+Press the *[.underline]##N##ew* button in the *_Patient vaccines browsing_* window to access the *_New patient vaccine_* window shown below.
 
 image:image73.png[image,width=530,height=360]
 
@@ -1112,16 +1205,18 @@ To record a new patient vaccination enters the following fields:
 * *Vaccine type:* the Vaccine Type
 * *Vaccine:* the Vaccine
 
-NOTE: _VaccineTypes and Vaccines can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: VaccineTypes and Vaccines can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm data and record the Patient vaccination
+* *[.underline]##O##K* to confirm data and record the Patient vaccination
 * *[.underline]##C##ancel* to close the window and to return to the *_Patient vaccines browsing_* window without record the patient vaccination
 
 ==== 9.2.3 Modify data of a recorded Patient vaccination ([.underline]##E##dit) 
 
-First of all, to modify data of a Patient vaccination you have to highlight it in the *_Patient vaccines browsing_* window. Once you’ve done this, press the *[.underline]##E##dit* button. When the *_Edit Patient vaccine_* window showed below appears, the record is available for changes. Date, vaccine type and vaccine can be changed.
+First of all, to modify data of a Patient vaccination you have to highlight it in the *_Patient vaccines browsing_* window. Once you have done this, 
+press the *[.underline]##E##dit* button. When the *_Edit Patient vaccine_* window shown below appears, the record is available for changes. Date, vaccine type and vaccine can be changed.
 
 image:image74.png[image,width=444,height=302]
 
@@ -1129,18 +1224,19 @@ You may change all data except the patient associated with this vaccination.
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm new values (all the previous values will be lost)
+* *[.underline]##O##K* to confirm new values (all the previous values will be lost)
 * *[.underline]##C##ancel* to close the window and to return to the Menu without applying any change
 
 ==== 9.2.4 Delete a Patient vaccination ([.underline]##D##elete)
 
-First of all, to delete a stored Patient vaccination you have to highlight it in the *_Patient vaccines browsing_* window. Secondly press the *[.underline]##D##elete* button. The confirmation window showed below will appear. The vaccination can then be deleted. Deleted vaccinations won’t be available anymore.
+First of all, to delete a stored Patient vaccination you have to highlight it in the *_Patient vaccines browsing_* window. Secondly 
+press the *[.underline]##D##elete* button. The confirmation window shown below will appear. The vaccination can then be deleted. Deleted vaccinations will not be available anymore.
 
 image:image75.png[image,width=278,height=187]
 
 === 9.3 Vaccines Extended (Patient [.underline]##V##accines)
 
-Since OpenHospital version 1.6 you can extend the Vaccine functionality by changing the _PATIENTVACCINEEXTENDED_ flag in the configuration file. Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+Since Open Hospital version 1.6 you can extend the Vaccine functionality by changing the _PATIENTVACCINEEXTENDED_ flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 ==== 9.3.1 New Vaccine Browsing (v 1.1.)
 
@@ -1152,6 +1248,7 @@ The only difference is the new column about the name of the patient for a fast r
 
 <<<
 
+[#admission-patient]
 == 10 Admission/Patient ([.underline]##A##dmission/Patient)
 
 === 10.1 Main Characteristics
@@ -1159,22 +1256,24 @@ The only difference is the new column about the name of the patient for a fast r
 Admission/Patient functionality allows registering a new patient, to modify his/her personal details, to browse his/her history, and to admit him/her in a hospital ward.
 
 .Click with the mouse on the button or press "Alt + A" to enter the *Patient Browser* window
-[#10-default-main-menu]
+[#default-main-menu-10]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
 
-NOTE: _You can also start an OPD registration from here if the OPDEXTENDED flag is set to YES. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: You can also start an OPD registration from here if the OPDEXTENDED flag is set to YES. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 === 10.2 Functions of Admission/Patients
 
-All functions available under *[.underline]##A##dmission/Patient* are accessible from the *_Patients browser_* window showed below.
+All functions available under *[.underline]##A##dmission/Patient* are accessible from the *_Patients browser_* window shown below.
 
 By default, the window shows in *Data table* all the patients currently present in the system.
 
 image:image78.png[image,width=584,height=235]
 
-NOTE: _If the patients list become huge it is possible to experience a slowdown of the system depending on the network settings. It is possible to optimize the use of memory by changing the flag ENHANCEDSEARCH in configuration file. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: If the patients list becomes huge it is likely to result in a slowdown of the system depending on the
+network settings. It is possible to optimize the use of memory by changing the flag ENHANCEDSEARCH in the
+configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 The following data are shown in the *_Patients browser_* window:
 
@@ -1199,13 +1298,14 @@ The following functions are accessible from the *Buttons Panel* of the window *_
 * *[.underline]##T##herapy* to manage the therapy of a patient
 * *[.underline]##C##lose* to exit from the function Admission/Patients and return to the main menu
 
-NOTE: _It is possible to have a *[.underline]##M##erge* function that might help in case of double patient registration, by changing the flag MERGEFUNCTION in configuration file. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: It is possible to have a *[.underline]##M##erge* function that might help in case of double patient
+registration, by changing the flag MERGEFUNCTION in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 Furthermore, a search function is available using the *Selection panel* on the left of the window.
 
 ====  10.2.1 Search patient 
 
-Queries about Patients can be done using the search criteria available on the *Selection panel* area of the window (left side of the window). Results of your search are showed on the *Data table* area.
+Queries about Patients can be done using the search criteria available on the *Selection panel* area of the window (left side of the window). Results of your search are shown on the *Data table* area.
 
 Doing the selection, data about patients can be selected by choosing specific fields among the following ones:
 
@@ -1217,36 +1317,38 @@ Doing the selection, data about patients can be selected by choosing specific fi
 * *Ward.* You can select one or more wards between Maternity, Nursery, Surgery, Internal medicine
 * *Age.* You can filter the patients list by age range
 * *Sex.* You can filter the patients list by gender
-* *Search criteria.* You can digit the complete name of a patient or only same characters: the system will show all the patients that have the entered characters (Examples are: if you enter “solo wa” all patients that have “solo [.underline]#wa#” in the name will be selected, “Solomon Wakunga” but also “Kamwa Solonik” will be showed).
+* *Search criteria.* You can digit the complete name of a patient or only same characters: the system will show all the patients that have the entered characters (Examples are: if you enter “solo wa” all patients that have “solo [.underline]#wa#” in the name will be selected, “Solomon Wakunga” but also “Kamwa Solonik” will be shown).
 
 image:image79.png[image,width=408,height=336]
 
-NOTE: _Wards can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: Wards can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
 ====  10.2.2 Search patient Enhanced
 
-OpenHospital, since version 1.6, allows optimizing memory usage when the number of registered patients becomes huge, by changing the _ENHANCEDSEARCH_ flag in the configuration file. Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+Open Hospital, since version 1.6, allows optimizing memory usage when the number of registered patients becomes huge, by changing the _ENHANCEDSEARCH_ flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 Once the enhanced search has been enabled the new *_Patients browser_* window will looks like following one:
 
 image:image80.png[image,width=338,height=172]
 
-Initially the list looks empty. In order to show some patient, you must enter a search criterion in *Search Key* field and the press the search (image:image81.png[zoom_r_button.png,width=15,height=15]) button and the window will show the only patients matching specified criteria.
+Initially the list looks empty. In order to show some patient, you must enter a search criterion in 
+*Search Key* field and then press the search (image:image81.png[zoom_r_button.png,width=15,height=15]) button and the window will show the only patients matching specified criteria.
 
 image:image82.png[image,width=628,height=319]
 
-Moreover, further search criterions are added in this modality:
+Moreover, further search criteria are added in this modality:
 
 * *Admission date.* To search all patients admitted in between the specified date, regardless if still admitted or not
 * *Discharge date.* To search all patients discharged in between the specified date, regardless if admitted again later on
 
-NOTE: _to show the full patient list again, is enough to press the search button with an empty criterion_
+NOTE: To show the full patient list again just press the search button with an empty search criterion.
 
 === 10.3 Insert a new Patient ([.underline]##N##ew Patient)
 
 You can use this function to register a new Patient when she/he is admitted in the Hospital.
 
-Press *[.underline]##N##ew Patient* button in the *_Patients browser_* window to access the *_New Patient_* window showed below.
+Press the *[.underline]##N##ew Patient* button in the *_Patients browser_* window to access the *_New Patient_* window shown below.
 
 image:image83.png[image,width=416,height=386]
 
@@ -1264,23 +1366,25 @@ To record a new patient, enter the following fields:
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm data and record the Patient
+* *[.underline]##O##K* to confirm data and record the Patient
 * *[.underline]##C##ancel* to close the window and to return to the *_Patient browser_* window without record the patient
 
 ====  10.3.1 Modify data of a recorded Patient ([.underline]##E##dit Patient) 
 
-First of all, to modify data of a Patient you have to highlight it in the *_Patient browser_* window. Once you’ve done this, press the *[.underline]##E##dit Patient* button. When the *_New Patient_* window showed below appears, the record is available for changes. All data can be changed.
+First of all, to modify data of a Patient you have to highlight it in the *_Patient browser_* window. Once you have done this, 
+press the *[.underline]##E##dit Patient* button. When the *_New Patient_* window shown below appears, the record is available for changes. All data can be changed.
 
 image:image83.png[image,width=416,height=386]
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm new values (all the previous values will be lost)
+* *[.underline]##O##K* to confirm new values (all the previous values will be lost)
 * *[.underline]##C##ancel* to close the window and to return to the Menu without applying any change
 
 ====  10.3.2 Delete a Patient (Dele[.underline]##t##e Patient)
 
-First of all, to delete a stored Patient you have to highlight it in the *_Patients browser_* window. Secondly press the *Dele[.underline]##t##e Patient* button. The name of the Patient will be showed in the *_Delete Patient_* window below. The record can then be deleted. Deleted records won’t be available anymore. _The patient will not completely remove from the system and you can ask to the Administrator to rescue his/her data at any time._
+First of all, to delete a stored Patient you have to highlight it in the *_Patients browser_* window. 
+Secondly press the *Dele[.underline]##t##e Patient* button. The name of the Patient will be shown in the *_Delete Patient_* window below. The record can then be deleted. Deleted records will not be available anymore. _The patient will not completely remove from the system and you can ask to the Administrator to rescue his/her data at any time._
 
 image:image84.png[image,width=278,height=128]
 
@@ -1289,9 +1393,10 @@ In the *Buttons Panel* you have the following choices:
 * *[.underline]##S##i* to confirm the record deletion
 * *[.underline]##N##o* to close the window and return to the previous window
 
+[#insert-a-new-patient-extended]
 === 10.4 Insert a new Patient Extended ([.underline]##N##ew Patient)
 
-Since OpenHospital version 1.3.1 you can extend the New Patient functionality by changing the _PATIENTEXTENDED_ flag in the configuration file. Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+Since Open Hospital version 1.3.1 you can extend the New Patient functionality by changing the _PATIENTEXTENDED_ flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 ====  10.4.1 New features
 
@@ -1316,53 +1421,59 @@ In any case it will be converted to an age in years in the *_Patients browser_* 
 * *Has Insurance*: you may specify if the patient has a health financial protection
 * *Load File*: could be used to load a patient picture (will be cropped squared)
 
-NOTE: _AgeTypes (Descriptions) can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: AgeTypes (Descriptions) can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
 ====  10.4.2 Height and Weight functionality (Height and Weight)
 
-Since OpenHospital 1.8, the height and weight of the patient is no longer registered during patient creation. It is done through the examination module available in the *_Admission browser_* window.
+Since Open Hospital 1.8, the height and weight of the patient is no longer registered during patient creation. It is done through the examination module available in the *_Admission browser_* window.
 
 ====  10.4.3 Patient Photo (New Photo)
 
-You can extend the New Patient functionality by changing the __VIDEOMODULEENABLED [.underline]# #__flag in the configuration file. Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+You can extend the New Patient functionality by changing the
+__[.underline]#VIDEOMODULEENABLED#__ flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 Once the video module has been enabled the *New Patient Extended* window will looks as follow:
 
 image:image86.png[New Patient Extended_photo.PNG,width=587,height=339]
 
-By clicking on *New Photo* button, the webcam should be activated (check any light on the device) and in the template you should see the “eye-view” of the camera.
+By clicking on the *New Photo* button, the webcam should be activated (check any light on the device) and in the template you should see the “eye-view” of the camera.
 
 image:image89.png[image,width=591,height=392]
 
 image:image90.png[image,width=156,height=119]
 
-By clicking again on *New Photo* button, you will make a shot ready to be saved in the system attached at the patient information.
+By clicking again on the *New Photo* button, you will make a shot ready to be saved in the system attached at the patient information.
 
 ===== 10.4.3.1 Camera settings (image:image91.png[switchcam.png,width=22,height=12])
 
-If nothing happens when you press on *New Photo* button you can press the *switch camera* button image:image91.png[switchcam.png,width=22,height=12] that allows switching among the webcams connected to the computer if more than one; if only one camera is connected to the computer it is useful to reset the camera settings and restart it.
+If nothing happens when you press the *New Photo* button you can press the *switch camera* button image:image91.png[switchcam.png,width=22,height=12] that allows switching among the webcams connected to the computer if more than one; if only one camera is connected to the computer it is useful to reset the camera settings and restart it.
 
 Once the camera is activated and you can see the “eye-view” of the camera, you may press on “+” or “-“ to increase or reduce the image quality.
 
-OpenHospital will try automatically to set the best quality for any webcam connected to the computer and will remember the last settings used.
+Open Hospital will try automatically to set the best quality for any webcam connected to the computer and will remember the last settings used.
 
-NOTE: _If the camera refuse to work is possible to check the problem deeper changing the flag DEBUG in configuration file. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: If the camera does not change the flag DEBUG in configuration file in order to generate additional
+diagnostic information. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 ===  10.5 Admission functions ([.underline]##A##dmission)
 
 The admission functions include the managing of a patient admission, including surgery, delivery, and discharge.
 
-To access the Admission function, first of all you have to highlight the Patient in the *_Patients browser_* window. Secondly press the *[.underline]##A##dmission* button.
+To access the Admission function, first of all you have to highlight the Patient in the *_Patients browser_* window. 
+Secondly press the *[.underline]##A##dmission* button.
 
 If the patient is not admitted then the *_New admission_* window appears.
 
 If the patient is already admitted then the *_Edit admission record_* window appears.
 
+[#start-the-admission-of-a-patient]
 ====  10.5.1 Start the admission of a patient ([.underline]##A##dmission)
 
 Once a patient is registered, he/her can be admitted in a hospital ward.
 
-First of all, to insert the admission of a patient you have to highlight the patient in the *_Patients browser_* window. Once you’ve done this, press the *[.underline]##A##dmission* button. The *_New admission_* window showed below appears (if the patient is already admitted the *_Edit admission record_* window appears).
+First of all, to insert the admission of a patient you have to highlight the patient in the *_Patients browser_* window. Once you have done this, 
+press the *[.underline]##A##dmission* button. The *_New admission_* window shown below appears (if the patient is already admitted the *_Edit admission record_* window appears).
 
 image:image92.png[image,width=637,height=334]
 
@@ -1378,25 +1489,33 @@ To start an admission, you have to enter the following fields (on the right side
 
 TIP: It is possible to filter in order to find diseases more easily. To do this, you will need to enter a text fragment in the search fields that is part of the disease name. The closer the search text comes to the name of the disease being searched for, the more precise the search is.
 
-NOTE: _Wards, AdmissionType and Diagnosis can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: Wards, AdmissionType and Diagnosis can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
-NOTE: _The "Progressive in year" field is automatically populated by the program; in case of maternity the counter can starts from first January or from first June as far as the current normative ask to the health facilities; to change this behaviour please ask to your Administrator to set the MATERNITYRESTARTINJUNE [.underline]# # flag in the configuration file or read the Administrator’s Guide._
+NOTE: The "Progressive in year" field is automatically populated by the program; in case of maternity the
+counter can start from the first January or from the first June as far as the current normative for the
+health facility.  To change the behavior please ask your Administrator to set the
+[.underline]#MATERNITYRESTARTINJUNE# flag in the configuration file or read the _Administrator’s Guide_.
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
 * *[.underline]##S##ave* to confirm the values on the window
 * *[.underline]##C##lose* to close the window and to return to the *_Patient browser_* window without applying any changes
-* *[.underline]##E##xamination* to open the *_Examination_* window (See 10.5.2 Patient examination).
+* *[.underline]##E##xamination* to open the *_Examination_* window (See
+<<patient-examination,Patient examination>>).
 
 Once you press the Save button the *_New admission_* window will close and you will see the status changed in the *_Patients browser_* window as follow figure:
 
 image:image93.png[Admission Patient_admitted.PNG,width=642,height=167]
 
+[#patient-examination]
 ====  10.5.2 Patient examination
 
-Since OpenHospital 1.8, you can register patient general parameters such as weight, height, arterial pressure, heart rate, Temperature, saturation, respiratory rate, and auscultation. Open hospital also calculates automatically the patient BMI.
+Since Open Hospital 1.8, you can register patient general parameters such as weight, height, arterial pressure, heart rate, Temperature, saturation, respiratory rate, and auscultation. Open hospital also calculates automatically the patient BMI.
 
-You have two ways to access the module. In the *_Patient browser_* window, highlight the patient and click *[.underline]##E##xamination.* Or in the *_Admission_* window, click the *[.underline]##E##xamination* button bellow. The following window will appear.
+You have two ways to access the module. In the *_Patient browser_* window, highlight the patient 
+and click *[.underline]##E##xamination.* Or in the *_Admission_* window,
+click the *[.underline]##E##xamination* button bellow. The following window will appear.
 
 image:image94.png[Examination.PNG,width=642,height=310]
 
@@ -1418,16 +1537,17 @@ Then enter following information:
 * *Auscultation*: Patient auscultation. This will default to unknown if not specified. Options currently include: Unknown, Normal, Wheezes, Rhonchi, Crackles, Stridor, Bronchial.
 * *Complain*: Any additional note concerning the examination
 
-After typing data, OpenHospital automatically calculate the BMI and display the result on the human figure at the left.
+After typing data, Open Hospital automatically calculate the BMI and display the result on the human figure at the left.
 
 Where everything is correct, click *[.underline]##S##ave* to save the examination.
 
 Select one or more records in the table and click *[.underline]##D##elete* to delete it/them.
 
+[#insert-or-modify-surgery-data]
+====  10.5.3 Insert or Modify Surgery data
 
-====  10.5.3 Insert/modify Surgery data
-
-First of all, to insert/modify operations data of a patient admission you have to highlight the patient in the *_Patients browser_* window. Once you’ve done this, press the *[.underline]##A##dmission* button. The *_Edit admission record_* window showed above appears.
+First of all, to insert/modify operations data of a patient admission you have to highlight the patient in the *_Patients browser_* window. Once you have done this, 
+press the *[.underline]##A##dmission* button. The *_Edit admission record_* window shown above appears.
 
 You can also insert/modify operations data directly when you are inserting or modifying an admission by selecting the *Operation tab* in the top of the window
 
@@ -1441,19 +1561,23 @@ Operations data that you can manage are:
 
 image:image95.png[Admission_operation.PNG,width=642,height=345]
 
-Since OpenHospital version 1.9, it is possible to record several operations at once. The buttons *_New_*, *_Save_* and *_Delete_* at the top right of the table allow you to manipulate the items of the table.
+Since Open Hospital version 1.9, it is possible to record several operations at once. The buttons *_New_*, *_Save_* and *_Delete_* at the top right of the table allow you to manipulate the items of the table.
 
-To add a new operation, click on the button *_New_* and enter the data as mentioned above and then click on *_Save_*.
+To add a new operation, click on the button *_New_* and enter the data as mentioned above and then 
+click on *_Save_*.
 
 WARNING: Clicking on the button *_Save_* just adds the operation to the table; it is not yet permanently recorded. 
 
-To delete a line from the table, select the line to delete by clicking on it (it automatically highlights), then click on the button *_Delete_*. When you are finished, click on the button *Save* below the table to save your changes.
+To delete a line from the table, select the line to delete by clicking on it (it automatically highlights), 
+then click on the button *_Delete_*. When you are finished, click on the button *Save* below the table to save your changes.
 
-NOTE: _OperationType and Operations can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: OperationType and Operations can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
-====  10.5.4 Insert/modify Delivery data
+[#insert-or-modify-delivery-data]
+====  10.5.4 Insert or Modify Delivery data
 
-If a female patient is admitted, the Maternity ward will be present in the ward list and, by selecting it, the *_Edit admission record_* window will change as showed below:
+If a female patient is admitted, the Maternity ward will be present in the ward list and, by selecting it, the *_Edit admission record_* window will change as shown below:
 
 In the window extension you will be able to specify much information about the Maternity Case, like:
 
@@ -1468,11 +1592,14 @@ In the window extension you will be able to specify much information about the M
 
 image:image96.png[Admission_delivery.PNG,width=642,height=339]
 
-NOTE: _TreatmentType, DeliveryType and DeliveryResultType can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: TreatmentType, DeliveryType and DeliveryResultType can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
+[#discharge-of-a-patient]
 ====  10.5.5 Discharge of a patient ([.underline]##A##dmission)
 
-First of all, to discharge a patient from the hospital you have to highlight the patient in the *_Patients browser_* window. Once you’ve done this, press the *[.underline]##A##dmission* button. The *_Edit admission record_* window showed above appears.
+First of all, to discharge a patient from the hospital you have to highlight the patient in the *_Patients browser_* window. Once you have done this, 
+press the *[.underline]##A##dmission* button. The *_Edit admission record_* window shown above appears.
 
 You have to enter the following data:
 
@@ -1484,7 +1611,8 @@ TIP: As in the case of *_Diagnosis IN_*, it is possible to filter to find diseas
 
 image:image97.png[Admission_discharge.PNG,width=642,height=337]
 
-NOTE: _DischargeTypes and Diseases can be defined by the Administrator. Ask to your Administrator how to do it or see link:#14-general-data-general-data[General Data] in this document._
+NOTE: DischargeTypes and Diseases can be defined by the Administrator. Ask your Administrator how to do it or see
+<<general-data,General Data>> in this document.
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
@@ -1498,17 +1626,20 @@ image:image98.png[Admission Patient_discharged.PNG,width=642,height=168]
 
 ===  10.6 OPD ([.underline]##O##PD)
 
-If _OPDEXTENDED_ flag is set as YES in the configuration file (ask to your Administrator) the button *[.underline]##O##PD* in the Admission/Patient window will allow you to start an OPD by selecting the related patient first (see link:#5_2_2_create_a_new_patient_visit_new[Create a new patient visit (New)] for more information)
+If _OPDEXTENDED_ flag is set as YES in the configuration file (Ask your Administrator) the button *[.underline]##O##PD* in the Admission/Patient window will allow you to start an OPD by selecting the related patient first (see
+<<create-a-new-patient-visit,Create a new patient visit>> for more information).
 
 === 10.7 Bill ([.underline]##B##ill)
 
-The button *[.underline]##B##ill* in the Admission/Patient window will allow you to start a bill by selecting the related patient first (see link:#8_2_1_insert_a_new_bill_new_bill[Insert a new bill (New Bill)] for more information)
+The button *[.underline]##B##ill* in the Admission/Patient window will allow you to start a bill by selecting the related patient first (see
+<<insert-a-new-bill,Insert a new bill>> for more information).
 
 ===  10.8 Manage Patient historical data ([.underline]##D##ATA)
 
 This function allows modifying data of a Patient and modify/delete the history of out of patients/admissions of a patient. Malnutrition can also be managed with this function.
 
-To access the Patient historical data function, first of all you have to highlight the Patient in the *_Patient browser_* window. Secondly press the *[.underline]##D##ATA* button. The *_Patient data_* window showed below will appear.
+To access the Patient historical data function, first of all you have to highlight the Patient in the *_Patient browser_* window. 
+Secondly press the *[.underline]##D##ATA* button. The *_Patient data_* window shown below will appear.
 
 image:image99.png[image,width=575,height=423]
 
@@ -1532,7 +1663,7 @@ The following functions are accessible from the *Buttons Panel* of the window *_
 
 ====  10.8.1 Modify data of an admission or out-patient visit ([.underline]##E##DIT) 
 
-First of all, to modify data of an admission or out-patient visit you have to highlight it in *Data table* of the *_Patient Data_* window. Once you’ve done this, press the *[.underline]##E##DIT* button. When the *_Edit admission record_* window showed below appears, the record is available for changes. All data can be changed.
+First of all, to modify data of an admission or out-patient visit you have to highlight it in *Data table* of the *_Patient Data_* window. Once you have done this, press the *[.underline]##E##DIT* button. When the *_Edit admission record_* window shown below appears, the record is available for changes. All data can be changed.
 
 image:image100.png[image,width=642,height=333]
 
@@ -1543,7 +1674,8 @@ When you finish entering data in the *Buttons Panel* you have the following choi
 
 ====  10.8.2 Delete an admission ([.underline]##D##ELETE)
 
-First of all, to delete a stored admission you have to highlight it in the *_Patient Data_* window. Secondly press the *[.underline]##D##ELETE* button. A confirmation window will appear and it is showed below. Now the admission can be deleted. Deleted admissions won’t be available anymore.
+First of all, to delete a stored admission you have to highlight it in the *_Patient Data_* window. 
+Secondly press the *[.underline]##D##ELETE* button. A confirmation window will appear and it is shown below. Now the admission can be deleted. Deleted admissions will not be available anymore.
 
 image:image101.png[image,width=278,height=128]
 
@@ -1558,7 +1690,8 @@ Malnutrition control function is available for all and only the admissions that 
 
 Malnutrition Control function allows you to register specified visits for those patients who need to control his/her Weight/Height index.
 
-To access the Malnutrition control function, first of all you have to highlight the admission in the *_Patient data_* window. Secondly press the *[.underline]##M##alnutrition control* button. The *_Malnutrition browser_* window showed below will appear.
+To access the Malnutrition control function, first of all you have to highlight the admission in the *_Patient data_* window. 
+Secondly press the *[.underline]##M##alnutrition control* button. The *_Malnutrition browser_* window shown below will appear.
 
 image:image102.png[Malnutrition Browser.PNG,width=642,height=288]
 
@@ -1581,14 +1714,16 @@ To record a new control, enter the following fields:
 
 The Clinical Sheet functionality is very similar to the *[.underline]##D##ATA* functionality (see *_Patients browser_* window)
 
-To access the Clinical sheet function, first of all you have to highlight the Patient in the *_Patients browser_* window. Secondly press the *[.underline]##C##linical sheet* button. The *_Patient data_* window showed below will appear.
+To access the Clinical sheet function, first of all you have to highlight the Patient in the *_Patients browser_* window. 
+Secondly press the *[.underline]##C##linical sheet* button. The *_Patient data_* window shown below will appear.
 
 image:image104.png[image,width=624,height=368]
 
-The window doesn't allow you to change data but, for the selected patient, it shows you all the out-patient (OPD) visits, the Admissions, his/her Laboratory exams and the various surgeries he/she underwent; by clicking on a row in the *Data table* on the top of the window, the related laboratory exams will be showed as follow:
+The window does not allow you to change data but, for the selected patient, it shows you all the out-patient (OPD) visits, the Admissions, his/her Laboratory exams and the various surgeries he/she underwent; 
+by clicking on a row in the *Data table* on the top of the window, the related laboratory exams will be shown as follow:
 
-* selected row is an Admission: all the exams done between the admission date and the discharge date will be showed in *Data table*, in the *_Exams_* tab
-* selected row is an out-patient (OPD) visit: all the exams done after the selected OPD visit until next one (if any) or next admission date (if any) will be showed in the *Data table*, in the *_Exams_* tab
+* selected row is an Admission: all the exams done between the admission date and the discharge date will be shown in *Data table*, in the *_Exams_* tab
+* selected row is an out-patient (OPD) visit: all the exams done after the selected OPD visit until next one (if any) or next admission date (if any) will be shown in the *Data table*, in the *_Exams_* tab
 
 The tab *_Operations_* shows the various operations recorded for the selected patient between the admission date and the discharge date. 
 
@@ -1601,24 +1736,25 @@ In the *Buttons Panel* you have the following choices:
 * *[.underline]#DICOM#* to launch DICOM viewer
 * *[.underline]##C##lose* to close the window and to return to the *_Patient browser_* window without applying any changes
 
-NOTE: _You need to change the DICOM flag in the configuration file to activate the DICOM functionality. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: You need to change the DICOM flag in the configuration file to activate the DICOM functionality. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
-By pressing the *#L#aunch report* button from the Clinical Sheet window, a new window will show up:
+By pressing the *[.underline]##L##aunch report* button from the Clinical Sheet window, a new window will show up:
 
 image:image244.png[image,width=400,height=456]
 
 The application will be automatically set to get the whole history of the patient, but you can change the produced report by querying a different dates range and specific set of information.
 
-
+[#dicom-viewer]
 ====  10.9.1 DICOM ([.underline]#DICOM viewer#)
 
-You need to change the DICOM flag in the configuration file to activate the DICOM functionality. Ask to your Administrator how to do it or read the Administrator’s Guide.
+You need to change the DICOM flag in the configuration file to activate the DICOM functionality. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
-On the patient Data window, click *DICOM* button to access the *_DICOM viewer_* window as shown below.
+On the patient Data window, click the *DICOM* button to access the *_DICOM viewer_* window as shown below.
 
 image:image105.png[DICOM viewer.PNG,width=642,height=361]
 
-This module allows you to attach DICOM files to the patient’s folder. In order to do this, click *Load DICOM* button. The following window will appear.
+This module allows you to attach DICOM files to the patient’s folder. In order to do this, 
+click the *Load DICOM* button. The following window will appear.
 
 image:image106.png[Dicom open.PNG,width=517,height=366]
 
@@ -1626,17 +1762,17 @@ In case of multi-frame DICOM you can select a whole folder
 
 image:image106b.png[Dicom open multi-frame.PNG,width=517,height=366]
 
-You will be asked for the following data to be used for the DICOM (or the multi-frame DICOM serie):
+You will be asked for the following data to be used for the DICOM (or the multi-frame DICOM series):
 
 * *Date*: the system will propose the current date or other dates provided by the DICOM file itself
-* *Category (not mandatory)*: you will be asked for a Dicom category (see link:#14-2-14-dicom-types-dicom-type[Dicom Type]):
+* *Category (not mandatory)*: you will be asked for a Dicom category (see <<dicom-types,Dicom Types>>):
 * *Description*: the description to be used
 
 image:image243.png[Dicom info.PNG,width=282,height=200]
 
 *[.underline]#N.B.#* There's no *Edit DICOM*, so if you make a mistake, you have to *Delete DICOM* and re-*Load DICOM* again.
 
-Find the DICOM file on your computer and click *Open DICOM* button to load the file in the *_DICOM viewer_*.
+Find the DICOM file on your computer and click the *Open DICOM* button to load the file in the *_DICOM viewer_*.
 
 image:image107.png[Dicom file.PNG,width=642,height=362]
 
@@ -1646,13 +1782,16 @@ image:image108.png[DICOM file view.PNG,width=642,height=360]
 
 You can use *Zoom* slider to Zoom in or out the image.
 
-You can load more than one DICOM file to a patient folder. You can also delete a DICOM file from the patient folder. You just have to select the file in left view and click *Delete DICOM* button.
+You can load more than one DICOM file to a patient folder. You can also delete a DICOM file from the patient folder. You just have to select the file in left view and 
+click the *Delete DICOM* button.
 
-Since OpenHospital version 1.10 you can hide the thumbnails on the left by changing the _DICOMTHUMBNAILS_ flag in the configuration file. Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+Since Open Hospital version 1.10 you can hide the thumbnails on the left by changing the _DICOMTHUMBNAILS_ flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
+[#therapy-management]
 === 10.10 Therapy management ([.underline]##T##herapy)
 
-First of all, to manage the therapy of a patient you have to highlight the patient in the *_Patients browser_* window. Once you’ve done this, press the *[.underline]##T##herapy* button. The specific window for therapy management of the selected patient will appear. The window has no name, we call it *_Therapy_* window.
+First of all, to manage the therapy of a patient you have to highlight the patient in the *_Patients browser_* window. Once you have done this, 
+press the *[.underline]##T##herapy* button. The specific window for therapy management of the selected patient will appear. The window has no name, we call it *_Therapy_* window.
 
 From the *_Therapy_* window you can insert, modify or remove a therapy.
 
@@ -1662,9 +1801,10 @@ The window is complex, see the comments below to understand the structure.
 
 image:image109.png[../../Screen%20Shot%202019-07-26%20at%2015.45.36.png,width=642,height=375]
 
+[#add-a-therapy]
 ==== 10.10.1 Add a therapy ([.underline]##A##dd Therapy)
 
-To add a new therapy for the patient, press the *[.underline]##A##dd Therapy* button on the right of the window. The *_Therapy entry form_* window showed below will appear.
+To add a new therapy for the patient, press the *[.underline]##A##dd Therapy* button on the right of the window. The *_Therapy entry form_* window shown below will appear.
 
 A therapy defines for every pharmaceutical the quantity, frequency and period of use.
 
@@ -1672,7 +1812,7 @@ You can add more than one therapy for the same patient. The set of therapies def
 
 image:image110.png[../../Screen%20Shot%202019-07-26%20at%2015.46.22.png,width=642,height=313]
 
-NOTE: _To better explain how the function *Add a therapy* works, the *Therapy* window below (next page) shows the results of the therapy defined in the *Therapy entry form* window above._
+NOTE: To better explain how the function *Add a therapy* works, the *Therapy* window below (next page) shows the results of the therapy defined in the *Therapy entry form* shown above.
 
 To add a therapy, you have to enter the following fields:
 
@@ -1686,57 +1826,72 @@ To add a therapy, you have to enter the following fields:
 
 When you finish entering data in the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm data of the therapy. The therapy is not saved until you do not confirm it with the *[.underline]##S##AVE* button in the *_Therapy_* window (see *Save function* described below)
-* *[.underline]##C##ancel* to close the window and to return to the *_Therapy_* window
+* *[.underline]##O##K* to confirm data of the therapy. The therapy is not saved until you do not confirm it with the *[.underline]##S##AVE* button in the *_Therapy_* window (see
+<<save-function-therapy,Save function>> described below).
+* *[.underline]##C##ancel* to close the window and to return to the *_Therapy_* window.
 
 image:image111.png[../../Screen%20Shot%202019-07-26%20at%2015.47.10.png,width=642,height=372]
 
-==== 10.10.2 Modify a therapy ([.underline]##E##dit Therapy) 
+==== 10.10.2 Modify a therapy ([.underline]##E##dit Therapy)
 
-First of all, to modify a therapy you have to highlight one occurrence of the therapy (see box above) in the *_Therapy_* window. Once you’ve done this, press the **[.underline]##E##dit Therapy [.underline]# #**button. The *_Therapy entry form_* window will appear. You can modify all data as in the *Add a therapy* function.
+First of all, to modify a therapy you have to highlight one occurrence of the therapy (see box above)
+in the *_Therapy_* window. Once you have done this, press the **[.underline]##E##dit Therapy** button.
+The *_Therapy entry form_* window will appear. You can modify any of the data as in the *Add a therapy* function.
 
-See link:#10_10_1_add_a_therapy_add_therapy[Add a therapy (Add Therapy)] function for detailed description.
+See <<add-a-therapy,Add a therapy>> function for a detailed description.
 
 ====  10.10.3 Remove a therapy (Remove Therapy) 
 
-First of all, to remove a therapy you have to highlight one occurrence of the therapy (see box above) in the Therapy window. Pay attention! Once you’ve done this, pressing the *Remove Therapy* button, the therapy is removed. Therapy can be removed before or after the final saving (see *link:#8_2_1_9_save_function_save[Save function]* described below)
+First of all, to remove a therapy you have to highlight one occurrence of the therapy (see box above) in the
+Therapy window. Pay attention! Once you have done this, pressing the *Remove Therapy* button, the therapy is
+removed. Therapy can be removed before or after the final saving (see
+<<save-function-therapy,Save function>>).
 
+[#check-availability-of-the-pharmaceuticals]
 ====  10.10.4 Check availability of the pharmaceuticals ([.underline]##C##heck availability) 
 
-When you have entered the therapy plan (all the therapies of a patient) you can check the availability of the related pharmaceuticals in the hospital. If the pharmaceutical/s checked is/are present in the quantity requested by the therapy plan on the button panel on the right side of the *_Therapy_* window you see in green colour the text ”OK”
+When you have entered the therapy plan (all the therapies of a patient) you can check the availability of the related pharmaceuticals in the hospital. If the pharmaceutical/s checked is/are present in the quantity requested by the therapy plan on the button panel on the right side of the *_Therapy_* window you see in green color the text ”OK”:
 
 image:image112.png[Therapy_available.PNG,width=168,height=82]
 
-otherwise the application shows the small window showed below, called *_Therapy not available:_*
+If there is not sufficient quantities available, the application shows the small window (shown below), called *_Therapy not available:_*
 
 image:image113.png[image,width=310,height=149]
 
-This window provides you only information that the therapy is not available and does not block the input of the Therapy plan. You have to click *[.underline]##O##K* on the button to exit from the window.
+This window provides you only information that the therapy is not available and does not block the input of the Therapy plan. 
+You have to click the *[.underline]##O##K* on the button to exit from the window.
 
-After the check, on the *button panel* of the *_Therapy_* window you see in red colour the text “NOT AVAILABLE” if at least one of the involved drugs starting from today are not available or the test “AVAILABLE” otherwise.
+After the check, on the *button panel* of the *_Therapy_* window you see in red color the text “NOT AVAILABLE” if at least one of the involved drugs starting from today are not available or the test “AVAILABLE” otherwise.
 
-NOTE: _check can also be done therapy by therapy and not only at the end of the input of all the therapies._
+NOTE: The check can also be done therapy by therapy and not only at the end of the input of all the therapies.
 
-Check function is not mandatory, you can save the therapy plan also without checking the presence of the pharmaceuticals in the hospital (see link:#8_2_1_9_save_function_save[Save function] below).
+Check function is not mandatory, you can save the therapy plan also without checking the presence of the pharmaceuticals in the hospital (see
+<<save-function-therapy,Save function>> below).
 
+[#save-function-therapy]
 ==== 10.10.5 Save function ([.underline]##S##AVE)
 
-When you have completed the input of the therapy plan press the *[.underline]##S##AVE* button on the button panel of the *_Therapy_* window. Be aware that the therapy plan is saved when on the screen appears the *_Message_* window showed below with the message “Therapies plan saved”.
+When you have completed the input of the therapy plan press the *[.underline]##S##AVE* button on the button panel of the *_Therapy_* window. Be aware that the therapy plan is saved when on the screen appears the *_Message_* window shown below with the message “Therapies plan saved”.
 
-If you have not done the availability check (see link:#check-availability-of-the-pharmaceuticals-check-availability[*Check availability function*]) the *_Not checked_* window showed below appears.
+If you have not done the availability check (see
+<<check-availability-of-the-pharmaceuticals,Check availability of the pharmaceuticals>>) the *_Not checked_* window shown below appears.
 
 On the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm the therapy plan; you have to be aware that if you press *[.underline]##O##k* you have not checked the existence of the pharmaceuticals in the hospital. The application saves the therapy plan and shows the confirmation window showed below.
+* *[.underline]##O##K* to confirm the therapy plan; you have to be aware that if 
+you press *[.underline]##O##K* you have not checked the existence of the pharmaceuticals in the hospital. The application saves the therapy plan and shows the confirmation window shown below.
 * *[.underline]#Cancel#* to return to the *_Therapy_* window without saving the therapy plan.
 
 image:image114.png[image,width=343,height=128]
 
-If you have done the availability check (see link:#check-availability-of-the-pharmaceuticals-check-availability[*Check availability function*]) but the pharmaceuticals requested by the therapy plan do not exists in the hospital the *_Not available_* window showed below appears.
+If you have done the availability check (see
+<<check-availability-of-the-pharmaceuticals,Check availability of the pharmaceuticals>>) but the pharmaceuticals requested by the therapy plan do
+not exist in the hospital, the *_Not available_* window shown below appears.
 
 On the *Buttons Panel* you have the following choices:
 
-* *[.underline]##O##k* to confirm the therapy plan; you have to be aware that if you press *[.underline]##O##k* you have saved a therapy but there are not the requested pharmaceuticals in the hospital. The application saves the therapy plan and shows the confirmation window showed below.
+* *[.underline]##O##K* to confirm the therapy plan; you have to be aware that if 
+you press *[.underline]##O##K* you have saved a therapy but there are not the requested pharmaceuticals in the hospital. The application saves the therapy plan and shows the confirmation window shown below.
 * *[.underline]#Cancel#* to return to the *_Therapy_* window without saving the therapy plan.
 
 image:image115.png[image,width=302,height=128]
@@ -1749,7 +1904,7 @@ Press *[.underline]##O##K* to finish.
 
 ====  10.10.6 Close function (Close)
 
-Close function allows you to exit from the *_Therapy window._* Press the *Close* button to access the Close function. The *_Select an option_* *_window_* showed below appears. On the *Button panels* you have the following choices:
+Close function allows you to exit from the *_Therapy window._* Press the *Close* button to access the Close function. The *_Select an option_* *_window_* shown below appears. On the *Button panels* you have the following choices:
 
 * *[.underline]##Y##es:* this function is the same as the *Save function ([.underline]##S##AVE)* described above
 * *[.underline]##N##o* to return to the *_Therapy window_* without saving the therapy plan
@@ -1764,18 +1919,20 @@ image:image118.png[image,width=170,height=131]
 With these two checkboxes you can set the therapies plan for this patient as important (not implemented yet) and notifiable via SMS. Briefly:
 
 * therapies: will be notified to the patient with an SMS at 8:00am, with text “REMINDER: “ + therapy details
-* visits: will be notified to the patient with an SMS 24 hours before the scheduled date and time, with the text “REMINDER VISIT: “ + visit details (see <<_14_11_sms_manager_sms_manager>>)
+* visits: will be notified to the patient with an SMS 24 hours before the scheduled date and time, with the text “REMINDER VISIT: “ + visit details (see
+<<sms-manager,SMS Manager>>)
 
 ==== 10.10.8 Visits
 
  
-By clicking on *Add [.underline]#V#isit* button, the following window will appear
+By clicking on the *Add [.underline]##V##isit* button, the following window will appear:
 
 image:image118b.png[image,width=300,height=150]
 
 The patient is already selected, while other fields need to be set:
 
-* *Ward:* to specify the ward where the patient has to be received (it will be shown in the Worksheet, see <<_16_worksheet_worksheet>>)
+* *Ward:* to specify the ward where the patient has to be received (it will be shown in the Worksheet, see
+<<worksheet,Worksheet>>)
 * *Service:* a brief description of the service that will be provided to the patient (optional)
 * *Duration (Min):* the estimated duration of the service that will be provided (optional)
 * *Date and Time:* the date and the time for the appointment
@@ -1784,7 +1941,8 @@ Press *[.underline]##O##K* to save the appointment and it will be shown in the c
 
 image:image118c.png[image,width=600,height=302]
 
-TIP: _If you like, you could first consult the actual worksheet by pressing the *Worksheet* button, then the instructions are the same as in <<_16_worksheet_worksheet>>, with the only difference that the patient is already selected and fixed (cannot be changed in this operation)_
+TIP: If you like, you could first consult the actual worksheet by pressing the *Worksheet* button, then the instructions are the same as in
+<<worksheet,Worksheet>>, with the only difference that the patient is already selected and fixed (cannot be changed in this operation).
 
 
 === 10.11 Merge function ([.underline]##M##erge)
@@ -1795,11 +1953,11 @@ First of all, to merge data of two patients you have to highlight them in the *_
 
 image:image119.png[Admission Patient_merge.PNG,width=642,height=180]
 
-Once you’ve done this, press the *[.underline]##M##erge* button. The *_Merge_* window showed below appears:
+Once you have done this, press the *[.underline]##M##erge* button. The *_Merge_* window shown below appears:
 
 image:image120.png[Admission Patient_merge_confirm.PNG,width=403,height=177]
 
-By pressing Yes, the patient with smaller Code will be deleted and all his/her history transferred to the other one, it’s to say:
+By pressing Yes, the patient with smaller Code will be deleted and all his/her history transferred to the other one, it is to say:
 
 * Admission History
 * Height & Weight History
@@ -1815,18 +1973,19 @@ The old patient will be then deleted.
 
 ==== 10.11.1 Different Names
 
-In case you try to merge two patients with different names you will be asked to choose the final one, with the window showed below:
+In case you try to merge two patients with different names you will be asked to choose the final one, with the window shown below:
 
 image:image121.png[Admission Patient_merge_names.PNG,width=268,height=129]
 
 ==== 10.11.2 Different Sex
 
-In case you try to merge two patients with different sex you will be notice that the operation is not allowed, with the window showed below:
+In case you try to merge two patients with different sex you will be notice that the operation is not allowed, with the window shown below:
 
 image:image122.png[Admission Patient_merge_sex.PNG,width=277,height=118]
 
 <<<
 
+[#statistics]
 == 11 Statistics (S[.underline]##t##atistics)
 
 === 11.1 Main Characteristics
@@ -1834,13 +1993,16 @@ image:image122.png[Admission Patient_merge_sex.PNG,width=277,height=118]
 This functionality is the most important in order to extract data registered in previous ones.
 
 .Click with the mouse on the button or press "Alt + T" to enter the *Statistics Report Launcher*
-[#11-default-main-menu]
+[#default-main-menu-11]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
-OpenHospital comes with a set of reports made for the Ugandan Ministry of Health (HMIS) and for Kenyan Ministry of Health (MOH) as well as national independent reports (OH). Anyway, all these reports can be useful for any organization and can be added or removed as explained in the Admin Manual chapter “6 – Reports”.
+Open Hospital comes with a set of reports made for the Ugandan Ministry of Health (HMIS) and for
+Kenyan Ministry of Health (MOH) as well as national independent reports (OH).
+All of these reports may be useful for any organization and can be added or removed as explained in
+the Administrator Manual's chapter “6 – Reports”.
 
-OpenHospital 1.8.4 comes with this set of reports:
+Open Hospital 1.8.4 comes with the following set of reports:
 
 * OH001 - Registered Patients
 * OH003 - Registered patients by Age and Sex
@@ -1873,7 +2035,7 @@ OpenHospital 1.8.4 comes with this set of reports:
 
 === 11.2 Report Launcher (Launch Report)
 
-With this function you can produce all reports listed in previous paragraph. Once you press the *S[.underline]##t##atistics* button on the main menu the *_Report Launcher_* window showed below will appear:
+With this function you can produce all reports listed in previous paragraph. Once you press the *S[.underline]##t##atistics* button on the main menu the *_Report Launcher_* window shown below will appear:
 
 image:image124.png[image,width=642,height=121]
 
@@ -1887,11 +2049,12 @@ After some instants the JasperViewer® will show the generated report as follow:
 
 image:image125.png[Report.PNG,width=591,height=420]
 
-NOTE: _By default, an internal PDF viewer is used. You can use an external PDF reader by modifying the INTERNALVIEWER flag in the configuration file. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: By default, an internal PDF viewer is used. You can use an external PDF reader by modifying the INTERNALVIEWER flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
-You can save the report as PDF by clicking on save button (image:image66.png[Report_save.PNG,width=21,height=19]) or printing it by clicking on print button (image:image67.png[Report_print.PNG,width=21,height=18]).
+You can save the report as PDF by clicking on the save button (image:image66.png[Report_save.PNG,width=21,height=19]) or printing it by 
+clicking on the print button (image:image67.png[Report_print.PNG,width=21,height=18]).
 
-NOTE: _A PDF copy of every report is always saved within the folders of OpenHospital. Ask to your Administrator how to do it or read the Administrator’s Guide._
+NOTE: A PDF copy of every report is always saved within the folders of Open Hospital. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 <<<
 
@@ -1902,11 +2065,11 @@ NOTE: _A PDF copy of every report is always saved within the folders of OpenHosp
 This functionality is meant for print some information about the hospital like letterhead, list of exams, diseases, etc...
 
 .Click with the mouse on the button or press "Alt + R" to enter the *Printings Submenu*
-[#12-default-main-menu]
+[#default-main-menu-12]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
-OpenHospital comes, at moment, with only this couple of printings:
+Open Hospital comes, at moment, with only this couple of printings:
 
 * Exams List
 * Diseases List
@@ -1931,16 +2094,16 @@ This report will produce a report about the list of diseases, divided by types, 
 
 === 13.1 Main Characteristics
 
-Since OpenHospital version 1.7 you can use the Communication module by changing the _XMPPMODULEENABLED_ flag in the configuration file. Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+Since Open Hospital version 1.7 you can use the Communication module by changing the _XMPPMODULEENABLED_ flag in the configuration file. Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 .Click with the mouse on the button or press "Alt + M" to enter the *Communication* window.
-[#13-default-main-menu]
+[#default-main-menu-13]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
-With this functionality you can chat and share information with other users logged in the system, if in turn the application has been set in [.underline]#multi-user# mode and an [.underline]#XMPP Server# is active and running (Ask to your Administrator how to do it or read the _Administrator’s Guide)._
+With this functionality you can chat and share information with other users logged in the system, if in turn the application has been set in [.underline]#multi-user# mode and an [.underline]#XMPP Server# is active and running (Ask your Administrator how to do it or read the __Administrator’s Guide_)._
 
-The functionality, up to OpenHospital 1.7.0, allows following tasks:
+The functionality, up to Open Hospital 1.7.0, allows following tasks:
 
 * Chat
 * Admissions notifications
@@ -1949,13 +2112,13 @@ The functionality, up to OpenHospital 1.7.0, allows following tasks:
 
 === 13.2 Chat
 
-By pressing the *Co[.underline]##m##munication* the *_Communication_* window showed below will appear:
+By pressing the *Co[.underline]##m##munication* the *_Communication_* window shown below will appear:
 
 image:image129.png[Communication.PNG,width=367,height=275]
 
 It shows all users logged in the system. Some of them have a green circle near their names: it means that they are currently logged in the system and they are the only ones we can interact with. Others have the name close to a grey circle: it means that they logged at least one time in the past but are not using the system in this moment.
 
-By double-clicking on an active user (i.e. Allan in the figure above) we may start a chat session with him/her, as showed in the figures below:
+By double-clicking on an active user (i.e. Allan in the figure above) we may start a chat session with him/her, as shown in the figures below:
 
 image:image130.png[../../Screen%20Shot%202019-07-26%20at%2015.55.17.png,width=641,height=286]
 
@@ -1965,15 +2128,17 @@ To send a message to Allan we must type it on the white box at the bottom then p
 
 As told before, with the communication module we can share some events with other users.
 
-In the *_New Admission_* window, we will see a new box in the *Buttons Panel*, as showed below:
+In the *_New Admission_* window, we will see a new box in the *Buttons Panel*, as shown below:
 
 image:image131.png[Communication_admission.PNG,width=642,height=343]
 
-The box will list all users logged in the system in this moment (those ones with the green circle near the name) and you can decide to send an alert or not (nobody) in the moment we press the *[.underline]##S##ave* button.
+The box will list all users logged in the system in this moment (those ones with the green circle near the name) and you can decide to send an alert or not (nobody) in the moment 
+we press the *[.underline]##S##ave* button.
 
 ====  13.3.1 Admission Notifications
 
-If we choose to send a notification about this new admission to user Allan, when we press the *[.underline]##S##ave* button, he will see in his *_Communication_* window a message like “new patient admission:” followed by his/her name and the related ward.
+If we choose to send a notification about this new admission to user Allan, when we 
+press the *[.underline]##S##ave* button, he will see in his *_Communication_* window a message like “new patient admission:” followed by his/her name and the related ward.
 
 An example of Allan *_Communication_* window is shown below.
 
@@ -1981,7 +2146,8 @@ image:image132.png[Communication_admission_allan.PNG,width=377,height=284]
 
 ====  13.3.2 Discharge Notifications
 
-Similarly, this would happen for discharge events. If we choose to send a notification about a discharge to user Allan, when we press the *[.underline]##S##ave* button, he will see in his *_Communication_* window a message like “discharged patient:” followed by his/her name and the related DischargeType.
+Similarly, this would happen for discharge events. If we choose to send a notification about a discharge to user Allan, when 
+we press the *[.underline]##S##ave* button, he will see in his *_Communication_* window a message like “discharged patient:” followed by his/her name and the related DischargeType.
 
 An example of Allan *_Communication_* window is shown below.
 
@@ -1991,13 +2157,15 @@ image:image133.png[Communication_discharge_allan.PNG,width=377,height=285]
 
 As told before, with the communication module we can share some events with other users.
 
-In the *_Stock Movement Inserting - Discharge_* window we will see a new box at the bottom, as showed below:
+In the *_Stock Movement Inserting - Discharge_* window we will see a new box at the bottom, as shown below:
 
 image:image134.png[Communication_stockallert.PNG,width=397,height=500]
 
-The box become active and useful only if the movement is going to reduce the selected pharmaceutical under the critical level. So, we can decide to share this event with another user logged in the system at the moment we press the *[.underline]##O##k* button.
+The box become active and useful only if the movement is going to reduce the selected pharmaceutical under the critical level. So, we can decide to share this event with another user logged in the system at the moment 
+we press the *[.underline]##O##K* button.
 
-If we choose to send a notification about this discharging movement to user Allan, when we press the *[.underline]##O##k* button, he will see in his *_Communication_* window a message like “ALERT:” followed by the pharmaceutical name and the text “is about to end” as showed below:
+If we choose to send a notification about this discharging movement to user Allan, when we 
+press the *[.underline]##O##K* button, he will see in his *_Communication_* window a message like “ALERT:” followed by the pharmaceutical name and the text “is about to end” as shown below:
 
 image:image135.png[Communication_stockallert_allan.PNG,width=377,height=287]
 
@@ -2005,25 +2173,26 @@ image:image135.png[Communication_stockallert_allan.PNG,width=377,height=287]
 
 As told before, with the communication module we can share some events with other users.
 
-In the *_Report Launcher_* window, we will see a new box at the bottom, as showed below:
+In the *_Report Launcher_* window, we will see a new box at the bottom, as shown below:
 
 image:image136.png[Communication_reports.PNG,width=642,height=123]
 
 We can decide to produce and share the selected report with another user logged in the system at the moment we press the *Launch Report* button.
 
-If we choose to share the report with user Allan, when we press the *Launch Report* button, he will see in his *_Communication_* window a message like “*** admin wants to share with you this report:” followed by the report name and a clickable icon that will link Allan to the related report. An example of this message is shown below:
+If we choose to share the report with user Allan, when we press the *Launch Report* button, he will see in his *_Communication_* window a message like “** admin wants to share with you this report:” followed by the report name 
+and a clickable icon that will link Allan to the related report. An example of this message is shown below:
 
 image:image137.png[Communication_reports_allan.PNG,width=377,height=284]
 
 <<<
-
+[#general-data]
 == 14 General Data ([.underline]##G##eneral Data)
 
 === 14.1 Main Characteristics
 
-One of the Administration task is the setup of OpenHospital through the *[.underline]##G##eneral Data* functionality. It allows defining all “types” and “data” that are going to be used in OpenHospital.
+One of the Administration task is the setup of Open Hospital through the *[.underline]##G##eneral Data* functionality. It allows defining all “types” and “data” that are going to be used in Open Hospital.
 
-.Press *[.underline]##G##eneral Data* button or “Alt + G” to open the General Data Sub-Menu
+.Press the *[.underline]##G##eneral Data* button or “Alt + G” to open the General Data Sub-Menu
 [frame=none]
 [grid=none]
 [caption="Sub Menu: "]
@@ -2031,7 +2200,7 @@ One of the Administration task is the setup of OpenHospital through the *[.under
 |image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]|image:image0_DefaultGeneralDataMenu.png[Sub-Menu,width=185,height=527]
 |===
 
-Once you’ve pressed on *[.underline]##G##eneral Data* button from the main menu you access the *_General Data_* menu. From this menu you have the following functions available:
+Once you have pressed on *[.underline]##G##eneral Data* button from the main menu you access the *_General Data_* menu. From this menu you have the following functions available:
 
 * *[.underline]##T##ypes*: will bring to Types menu
 * *[.underline]##H##ospital*: to set some Hospital information (name, address, telephone, email, etc...)
@@ -2046,9 +2215,9 @@ Once you’ve pressed on *[.underline]##G##eneral Data* button from the main men
 
 ===  14.2 Types ([.underline]##T##ypes)
 
-Once you’ve pressed on *[.underline]##T##ypes* button from the *_General Data_* menu you access the *_Types_* menu:
+Once you have pressed on *[.underline]##T##ypes* button from the *_General Data_* menu you access the *_Types_* menu:
 
-.Press *[.underline]##T##ypes* button or “Alt + T” to open the Types Menu
+.Press the *[.underline]##T##ypes* button or “Alt + T” to open the Types Menu
 [frame=none]
 [grid=none]
 [caption="General Data Menu: "]
@@ -2090,7 +2259,7 @@ _i.e. X-Ray, CT-Scan, NMR, etc..._
 
 ====  14.2.1 Admission Types ([.underline]##A##dmission Type)
 
-Once you’ve pressed on *[.underline]##A##dmission Type* button from the *_Types_* menu you access the *_Disease Type Browsing_* window as showed below:
+Once you have pressed on *[.underline]##A##dmission Type* button from the *_Types_* menu you access the *_Disease Type Browsing_* window as shown below:
 
 image:image140.png[Admission Types.PNG,width=453,height=203]
 
@@ -2101,11 +2270,13 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Admission Types defined in this functionality will be reflected in the Admission function (see link:#10_5_1_start_the_admission_of_a_patient_admission[Start the admission of a patient] and link:#10_5_5_discharge_of_a_patient_admission[Discharge of a patient] in this document).
+The Admission Types defined in this functionality will be reflected in the Admission function (see
+<<start-the-admission-of-a-patient,Start the admission of a patient>> and
+<<discharge-of-a-patient,Discharge of a patient>> in this document).
 
 ====  14.2.2 Discharge Types ([.underline]##D##ischarge Type)
 
-Once you’ve pressed on *[.underline]##D##ischarge Type* button from the *_Types_* menu you access the *_Discharge Type Browsing_* window as showed below:
+Once you have pressed on *[.underline]##D##ischarge Type* button from the *_Types_* menu you access the *_Discharge Type Browsing_* window as shown below:
 
 image:image141.png[Discharge Types.PNG,width=453,height=194]
 
@@ -2116,11 +2287,13 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Discharge Types defined in this functionality will be reflected in the Admission function (see link:#10_5_1_start_the_admission_of_a_patient_admission[Start the admission of a patient] and link:#10_5_5_discharge_of_a_patient_admission[Discharge of a patient] in this document).
+The Discharge Types defined in this functionality will be reflected in the Admission function (see
+<<start-the-admission-of-a-patient,Start the admission of a patient>> and
+<<discharge-of-a-patient,Discharge of a patient>> in this document).
 
 ====  14.2.3 Delivery Types (De[.underline]##l##ivery Type)
 
-Once you’ve pressed on *De[.underline]##l##ivery Type* button from the *_Types_* menu you access the *_Delivery Type Browsing_* window as showed below:
+Once you have pressed on *De[.underline]##l##ivery Type* button from the *_Types_* menu you access the *_Delivery Type Browsing_* window as shown below:
 
 image:image142.PNG[Discharge Types.PNG,width=432,height=194]
 
@@ -2131,11 +2304,12 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Delivery Types defined in this functionality will be reflected in the Admission function (see link:#10_5_4_insertmodify_delivery_data[Insert or Modify Delivery Data] in this document).
+The Delivery Types defined in this functionality will be reflected in the Admission function (see
+<<insert-or-modify-delivery-data,Insert or Modify Delivery data>> in this document).
 
 ====  14.2.4 Delivery Result Types (Delive[.underline]##r##y Result Type)
 
-Once you’ve pressed on *Delive[.underline]##r##y Result Type* button from the *_Types_* menu you access the *_Delivery Result Type Browsing_* window as showed below:
+Once you have pressed on *Delive[.underline]##r##y Result Type* button from the *_Types_* menu you access the *_Delivery Result Type Browsing_* window as shown below:
 
 image:image143.png[Discharge Types.PNG,width=432,height=194]
 
@@ -2146,11 +2320,12 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Delivery Result Types defined in this functionality will be reflected in the Admission function (see link:#10_5_4_insertmodify_delivery_data in this document).
+The Delivery Result Types defined in this functionality will be reflected in the Admission function (see
+<<insert-or-modify-delivery-data,Insert or Modify Delivery data>> in this document).
 
 ====  14.2.5 Disease Types (Disease [.underline]##T##ype)
 
-Once you’ve pressed on *Disease [.underline]##T##ype* button from the *_Types_* menu you access the *_Disease Type Browsing_* window as showed below:
+Once you have pressed on *Disease [.underline]##T##ype* button from the *_Types_* menu you access the *_Disease Type Browsing_* window as shown below:
 
 ____
 image:image144.PNG[image,width=408,height=183]
@@ -2163,11 +2338,13 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Disease Types defined in this functionality will be reflected in the entire application, like in Disease definition or in OPD (see link:#14_5_disease_disease[Disease] and link:#5_2_2_create_a_new_patient_visit_new[Create a new patient visit] in this document).
+The Disease Types defined in this functionality will be reflected in the entire application, like in Disease definition or in OPD (see
+<<disease,Disease>> and <<create-a-new-patient-visit,Create a new patient visit>> in this document).
 
+[#exam-types]
 ====  14.2.6 Exam Types ([.underline]##E##xam Type)
 
-Once you’ve pressed on *[.underline]##E##xam Type* button from the *_Types_* menu you access the *_Exam Types Browser_* window as showed below:
+Once you have pressed on *[.underline]##E##xam Type* button from the *_Types_* menu you access the *_Exam Types Browser_* window as shown below:
 
 ____
 image:image145.png[image,width=407,height=183]
@@ -2180,11 +2357,12 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Exam Types defined in this functionality will be reflected in the Laboratory function (see link:#7_laboratory_laboratory[Laboratory] in this document).
+The Exam Types defined in this functionality will be reflected in the Laboratory function (see
+<<laboratory,Laboratory>> in this document).
 
 ====  14.2.7 Medicals Stock Movement Types (Medical[.underline]##s## Stock Mov Type)
 
-Once you’ve pressed on *Medical[.underline]##s## Stock Mov Type* button from the *_Types_* menu you access the *_Medicals Stock Movement Types Browsing_* window as showed below:
+Once you have pressed on *Medical[.underline]##s## Stock Mov Type* button from the *_Types_* menu you access the *_Medicals Stock Movement Types Browsing_* window as shown below:
 
 ____
 image:image146.png[image,width=407,height=183]
@@ -2197,7 +2375,7 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-By pressing the *[.underline]##N##ew* button, you access the *_New_* *_Medical Stock Movement Type_* window as showed below:
+By pressing the *[.underline]##N##ew* button, you access the *_New_* *_Medical Stock Movement Type_* window as shown below:
 
 image:image147.png[New Medical Stock Movement.PNG,width=250,height=227]
 
@@ -2211,11 +2389,12 @@ Examples could be:
 * Lost (-)
 * ...
 
-The Medical Stock Movement Types defined in this functionality will be reflected in the Pharmaceutical Stock function (see link:#6-2-2-3-insert-stock-discharging-movement-discharge[Insert stock movement] in this document).
+The Medical Stock Movement Types defined in this functionality will be reflected in the Pharmaceutical Stock function (see
+<<#insert-stock-discharging-movement,Insert Stock Discharging Movement>> in this document).
 
 ====  14.2.8 Medical Types ([.underline]##M##edical Type)
 
-Once you’ve pressed on *[.underline]##M##edical Type* button from the *_Types_* menu you access the *_Medical Type Browsing_* window as showed below:
+Once you have pressed on *[.underline]##M##edical Type* button from the *_Types_* menu you access the *_Medical Type Browsing_* window as shown below:
 
 ____
 image:image148.png[image,width=407,height=183]
@@ -2228,11 +2407,13 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Medical Types defined in this functionality will be reflected in the entire application, like in Pharmacy function and Pharmaceutical Stock Ward (see link:#6-1-2-1-insert-a-new-pharmaceutical-new[Insert a new pharmaceutical] and link:#6-3-2-2-search-ward-pharmacy-movements-filter[Search Ward Pharmacy movements] in this document).
+The Medical Types defined in this functionality will be reflected in the entire application, like in Pharmacy function and Pharmaceutical Stock Ward (see
+<<insert-a-new-pharmaceutical,Insert a new pharmaceutical>> and
+<<search-ward-pharmacy-movements,Search Ward Pharmacy movements>> in this document).
 
 ====  14.2.9 Operation Types ([.underline]##O##peration Type)
 
-Once you’ve pressed on *[.underline]##O##peration Type* button from the *_Types_* menu you access the *_Operation Type Browsing_* window as showed below:
+Once you have pressed on *[.underline]##O##peration Type* button from the *_Types_* menu you access the *_Operation Type Browsing_* window as shown below:
 
 image:image149.png[Discharge Types.PNG,width=432,height=194]
 
@@ -2243,11 +2424,12 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Operation Types defined in this functionality will be reflected in the Admission function (see link:#10-5-3-insertmodify-surgery-data[Insert/modify Surgery data]  in this document).
+The Operation Types defined in this functionality will be reflected in the Admission function (see
+<<insert-or-modify-surgery-data,Insert or Modify Surgery Data>>  in this document).
 
 ==== 14.2.10 Pregnant Treatment Types ([.underline]##P##regnant Treatment Type)
 
-Once you’ve pressed on *[.underline]##P##regnant Treatment Type* button from the *_Types_* menu you access the *_Pregnant Treatment Type Browsing_* window as showed below:
+Once you have pressed on *[.underline]##P##regnant Treatment Type* button from the *_Types_* menu you access the *_Pregnant Treatment Type Browsing_* window as shown below:
 
 image:image150.png[Discharge Types.PNG,width=432,height=194]
 
@@ -2258,11 +2440,13 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Pregnant Treatment Types defined in this functionality will be reflected in the Admission function (see link:#10-5-4-insertmodify-delivery-data in this document).
+The Pregnant Treatment Types defined in this functionality will be reflected in the Admission function (see
+<<insert-or-modify-delivery-data,Insert or Modify Delivery data>> in this document).
 
+[#other-prices]
 ==== 14.2.11 Other Prices (Ot[.underline]##h##er Prices)
 
-Once you’ve pressed on *Ot[.underline]##h##er Prices* button from the *_Types_* menu you access the *_Other Prices Browser_* window as showed below:
+Once you have pressed on *Ot[.underline]##h##er Prices* button from the *_Types_* menu you access the *_Other Prices Browser_* window as shown below:
 
 image:image151.png[Discharge Types.PNG,width=377,height=194]
 
@@ -2273,7 +2457,7 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing price (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-By pressing the *[.underline]##N##ew* button, you access the *_New_* *_Medical Stock Movement Type_* window as showed below:
+By pressing the *[.underline]##N##ew* button, you access the *_New_* *_Medical Stock Movement Type_* window as shown below:
 
 image:image152.png[New Prices.PNG,width=400,height=180]
 
@@ -2292,15 +2476,16 @@ image:image153.png[New Prices_daily.PNG,width=297,height=124]
 
 image:image154.png[New Prices_undefined.PNG,width=297,height=124]
 
-The Other Prices defined in this functionality will be reflected in the Accounting and PriceLists functions (see link:#8-2-1-insert-a-new-bill-new-bill[Insert a new bill] and link:#14-9-prices-price-lists[Prices] in this document).
+The Other Prices defined in this functionality will be reflected in the Accounting and PriceLists functions (see
+<<insert-a-new-bill,Insert a new bill>> and <<prices,Prices>> in this document).
 
 ==== 14.2.12 Age Types (A[.underline]##g##e Type)
 
-Once you’ve pressed on *A[.underline]##g##e Type* button from the *_Types_* menu you access the *_Age Type Browser_* window as showed below:
+Once you have pressed on *A[.underline]##g##e Type* button from the *_Types_* menu you access the *_Age Type Browser_* window as shown below:
 
 image:image155.png[Age Types.PNG,width=456,height=170]
 
-Since OpenHospital 1.7 age ranges are fixed and the Administrator can only change their values to best fit the health normative in the country.
+Since Open Hospital 1.7 age ranges are fixed and the Administrator can only change their values to best fit the health normative in the country.
 
 By pressing the *[.underline]##E##dit* button, the table will allow you to modify only the age values and the button become a *[.underline]##S##ave* button now:
 
@@ -2318,11 +2503,12 @@ In following case instead, ranges Late Childhood and Adolescent are *overlapped*
 
 image:image159.png[image,width=642,height=313]
 
-The Age Types defined in this functionality will be reflected in the Patient Extended functionality (see link:#10-4-insert-a-new-patient-extended-new-patient[Insert a new Patient Extended] in this document).
+The Age Types defined in this functionality will be reflected in the Patient Extended functionality (see
+<<insert-a-new-patient-extended,Insert a new Patient Extended>> in this document).
 
 ==== 14.2.13 Vaccine Types ([.underline]##V##accine Type)
 
-Once you’ve pressed on *[.underline]##V##accine Type* button from the *_Types_* menu you access the *_Vaccine Type Browsing_* window as showed below:
+Once you have pressed on *[.underline]##V##accine Type* button from the *_Types_* menu you access the *_Vaccine Type Browsing_* window as shown below:
 
 image:image161.png[Discharge Types.PNG,width=432,height=194]
 
@@ -2333,11 +2519,13 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Vaccine Types defined in this functionality will be reflected in the Vaccine function (see link:#9-vaccines-patient-vaccines[Vaccines] in this document).
+The Vaccine Types defined in this functionality will be reflected in the Vaccine function (see
+<<vaccines,Vaccines>> in this document).
 
+[#dicom-types]
 ==== 14.2.14 Dicom Types (Dicom Type)
 
-Once you’ve pressed on *Dicom Type* button from the *_Types_* menu you access the *_Dicom Type Browsing_* window as showed below:
+Once you have pressed on *Dicom Type* button from the *_Types_* menu you access the *_Dicom Type Browsing_* window as shown below:
 
 image:image242.png[Discharge Types.PNG,width=432,height=194]
 
@@ -2348,11 +2536,12 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing type (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-The Dicom Types defined in this functionality will be reflected in the Dicom Load function (see link:#10-9-1-dicom-dicom-viewer[Dicom Viewer] in this document).
+The Dicom Types defined in this functionality will be reflected in the Dicom Load function (see
+<dicom-viewer,Dicom Viewer>> in this document).
 
 === 14.3 Hospital ([.underline]##H##ospital)
 
-Once you’ve pressed on *[.underline]##H##ospital* button from the *_General Data_* menu you access the *_Hospital information_* window as showed below:
+Once you have pressed on *[.underline]##H##ospital* button from the *_General Data_* menu you access the *_Hospital information_* window as shown below:
 
 image:image162.png[Hospital.PNG,width=282,height=254]
 
@@ -2360,11 +2549,12 @@ By pressing the *[.underline]##E##dit* button, the fields will allow you to modi
 
 image:image163.png[Hospital_edit.PNG,width=282,height=254]
 
-By pressing the *[.underline]##U##pdate* button, the new information will be stored in the system and will be reflected in the entire application, like in reports heading (see link:#statistics-statistics[Statistics] in this document)
+By pressing the *[.underline]##U##pdate* button, the new information will be stored in the system and will be reflected in the entire application, like in reports heading (see
+<<statistics,Statistics>> in this document)
 
 === 14.4 Ward ([.underline]##W##ard)
 
-Once you’ve pressed on *[.underline]##W##ard* button from the *_General Data_* menu you access the *_Ward Browser_* window as showed below:
+Once you have pressed on *[.underline]##W##ard* button from the *_General Data_* menu you access the *_Ward Browser_* window as shown below:
 
 image:image164.png[Ward Browser.PNG,width=640,height=269]
 
@@ -2375,7 +2565,7 @@ The functions available from this window (but similarly to other windows in *_Ty
 * *[.underline]##D##elete*: to delete an already existing ward (cannot be deleted if still used somewhere in the application)
 * *[.underline]##C##lose*: to close the window
 
-By pressing the *[.underline]##N##ew* button, you access the *_New_* w**_ard record_** window as showed below:
+By pressing the *[.underline]##N##ew* button, you access the *_New_* w**_ard record_** window as shown below:
 
 image:image165.png[Ward Browser_new.PNG,width=336,height=355]
 
@@ -2390,13 +2580,17 @@ In order to insert a new Ward, you must provide following compulsive inputs:
 * *Male Ward*: if it is a male Ward
 * *Female Ward*: if it is a female Ward
 
-NOTE: _through this function we may define some wards with 0 - zero beds but with pharmacy, in order to have “logic” departments (rather than physical) to manage pharmacy movements_
+NOTE: Using this function one can define wards with 0 (zero) beds but with a pharmacy.
+This allows for "logical” departments (rather than physical) to manage pharmacy movements.
 
-The Wards defined in this functionality will be reflected in the entire application, like in Admission module, Pharmaceuticals Stock and Pharmaceuticals Stock Ward (see link:#10-admissionpatient-admissionpatient[Admission/Patient], link:#6-2-pharmaceutical-stock-pharmaceutical-stock[Pharmaceutical Stock] and link:#6-3-pharmaceuticals-stock-ward-pharmaceuticals-stock-ward[Pharmaceuticals Stock Ward] in this document).
+The Wards defined in this functionality will be reflected in the entire application, like in Admission module, Pharmaceuticals Stock and Pharmaceuticals Stock Ward (see
+<<admission-patient,Admission/Patient>>, <<pharmaceutical-stock,Pharmaceutical Stock>> and
+<<pharmaceutical-stock-ward,Pharmaceuticals Stock Ward>> in this document).
 
+[#disease]
 === 14.5 Disease ([.underline]##D##isease)
 
-Once you’ve pressed on *[.underline]##G##eneral Data* button from the *_General Data_* menu you access the *_Diseases Browser_* window as showed below:
+Once you have pressed on *[.underline]##G##eneral Data* button from the *_General Data_* menu you access the *_Diseases Browser_* window as shown below:
 
 image:image166.png[image,width=467,height=345]
 
@@ -2416,11 +2610,14 @@ In editing mode, you cannot change type and code but only modify the Description
 
 By removing the check from both checkboxes OPD and IPD you are performing a *[.underline]##D##elete* action, that is disabling it to not appear anymore in the application. Anyway, this can be changed anytime by editing it again.
 
-The Diseases defined in this functionality will be reflected in the entire application, like in Admission module and OPD module (see link:#10-admissionpatient-admissionpatient[Admission/Patient] and link:#5-outpatient-department-management-opd[Outpatient Department Management] in this document).
+The Diseases defined in this functionality will be reflected in the entire application, like in Admission module and OPD module (see
+<<admission-patient,Admission/Patient>> and
+<<outpatient-department-management,Outpatient Department Management>> in this document).
 
+[#exam]
 === 14.6 Exam ([.underline]##E##xams)
 
-Once you’ve pressed on *[.underline]##E##xams* button from the *_General Data_* menu you access the *_Exam Browsing_* window as showed below:
+Once you have pressed on *[.underline]##E##xams* button from the *_General Data_* menu you access the *_Exam Browsing_* window as shown below:
 
 image:image168.png[image,width=633,height=190]
 
@@ -2446,29 +2643,32 @@ image:image170.png[Exam Browsing_edit.PNG,width=373,height=240]
 
 In order to insert a new Exam, you must input the following data:
 
-* *Type*: is the Exam Type (see link:#14-2-6-exam-types-exam-type[Exam Types] in this document)
+* *Type*: is the Exam Type (see <<exam-types,Exam Types>> in this document)
 * *Code*: you cannot use an already used code; a warning window will appear in case
 * *Description*: is the exam name
-* *Procedure*: the kind of results for this exam (see link:#14-6-1-results-results[Results] in this document)
-* *Default*: a default value among the result we are going to define (see link:#14-6-1-results-results[Results] in this document)
+* *Procedure*: the kind of results for this exam (see <<results,Results>> in this document)
+* *Default*: a default value among the result we are going to define (see <<results,Results>> in this document)
 
+[#results]
 ====  14.6.1 Results (Re[.underline]##s##ults)
 
-Once you’ve inserted a new exam you may define the set of results it can allow by first selecting the exam in the *_Exam Browsing_* window and then by pressing on the *Re[.underline]##s##ults* button.
+Once you have inserted a new exam you may define the set of results it can allow by first selecting the exam in the *_Exam Browsing_* window and then by pressing on the *Re[.underline]##s##ults* button.
 
-In OpenHospital 1.7 you can define two kind of set of results, called “Procedure”:
+In Open Hospital 1.7 you can define two kind of set of results, called “Procedure”:
 
 * *Procedure 1*: a set of values as description; only one will be selectable as exam *Single Result*
 * *Procedure 2*: a set of Positive/Negative values; all of them will figure as exam *Multiple Results*
 * *Procedure 3*: a specific value to be input manually; it will show an *input field* at the time of the exam registration
 
-The difference between *Procedures (1, 2, 3)* will be seen in the Laboratory module (see link:#7-2-2-create-a-new-laboratory-exam-new[Create a new laboratory exam] and link:#7-3-3-laboratory-multiple-insert[Laboratory Multiple Insert] in this document)
+The difference between *Procedures (1, 2, 3)* will be seen in the Laboratory module (see
+<<create-a-new-laboratory-exam,Create a new laboratory exam>> and
+<<laboratory-multiple-insert,Laboratory Multiple Insert>> in this document).
 
-Since for [.underline]#Procedure 3# the exact value is not known, so the *[.underline]#R#esult* button is disable in this case:
+Since for [.underline]#Procedure 3# the exact value is not known, so the *[.underline]##R##esult* button is disable in this case:
 
 image:image170b.png[image,width=600,height=178]
 
-So, the two remaining possibilities are showed below:
+So, the two remaining possibilities are shown below:
 
 image:image171.png[image,width=321,height=181]image:image171b.png[image,width=321,height=181]
 
@@ -2479,9 +2679,10 @@ The functions available from both windows are:
 * *[.underline]##D##elete*: to delete an already inserted result
 * *[.underline]##C##lose*: to close the window
 
+[#operations]
 === 14.7 Operations ([.underline]##O##peration)
 
-Once you’ve pressed on *[.underline]##O##peration* button from the *_General Data_* menu you access the *_Operation Browser_* window as showed below:
+Once you have pressed on *[.underline]##O##peration* button from the *_General Data_* menu you access the *_Operation Browser_* window as shown below:
 
 image:image173.png[image,width=600,height=337]
 
@@ -2501,11 +2702,12 @@ In editing mode, you cannot change type and code but only modify the Description
 
 You can change instead at anytime the operation's context: _OPD / ADMISSION_, _ADMISSION_ (only), _OPD_ (only)
 
-The Operations defined in this functionality will be reflected in the entire application, like in Admission module (see link:#10-5-3-insertmodify-surgery-data[Insert/modify Surgery data]  in this document).
+The Operations defined in this functionality will be reflected in the entire application, like in Admission module (see
+<<insert-or-modify-surgery-data,Insert or Modify Surgery data]  in this document).
 
 === 14.8 Vaccine ([.underline]##V##accine)
 
-Once you’ve pressed on *[.underline]##V##accine* button from the *_General Data_* menu you access the *_Vaccine Browser_* window as showed below:
+Once you have pressed on *[.underline]##V##accine* button from the *_General Data_* menu you access the *_Vaccine Browser_* window as shown below:
 
 image:image175.png[image,width=597,height=168]
 
@@ -2525,11 +2727,13 @@ ____
 
 In editing mode, you cannot change type and code but only modify the Description.
 
-The Vaccines defined in this functionality will be reflected in the entire application, like in Vaccine module (see link:#9-vaccines-patient-vaccines[Vaccines] in this document).
+The Vaccines defined in this functionality will be reflected in the entire application, like in Vaccine module (see
+<<vaccines,Vaccines>> in this document).
 
+[#prices]
 === 14.9 Prices ([.underline]##P##rice Lists)
 
-Once you’ve pressed on *[.underline]##P##rice Lists* button from the *_General Data_* menu you access the *_Prices Browser_* window as showed below:
+Once you have pressed on *[.underline]##P##rice Lists* button from the *_General Data_* menu you access the *_Prices Browser_* window as shown below:
 
 image:image177.png[Prices Browser.PNG,width=550,height=373]
 
@@ -2539,23 +2743,29 @@ The functions available from this window are:
 * *[.underline]#Printing#*: to print the current Price List
 * *[.underline]##C##ancel*: to close the window
 * Switch pricelist: you can focus on a different pricelist by selecting it on the upper-left corner of the window
-* *Manage Lists*: you can define how many and which pricelist will be available in the application (see link:#14-9-1-pricelists-manage-lists[Pricelists] in this document)
+* *Manage Lists*: you can define how many and which pricelist will be available in the application (see
+<<pricelists,Pricelists>> in this document)
 
-The *_Prices Browser_* window shows the list of all prices in the selected pricelists; the system automatically creates a price for every Exam (see <<_14_6_exam_exams>>), Operation (see <<_14_7_operations_operation>>) and Medical (see <<_6_1_pharmaceuticals_pharmaceuticals>>) defined in the system, plus other prices defined in Other Prices module (see <<_14_2_11_other_prices_other_prices>>)
+The *_Prices Browser_* window shows the list of all prices in the selected pricelists;
+the system automatically creates a price for every Exam (see <<exam,Exam>>),
+Operation (see <<operations,Operations>>) and Medical (see <<pharmaceuticals,Pharmaceuticals>>) defined in
+the system, plus other prices defined in Other Prices module (see <<other-prices,Other Prices>>).
 
 In order to modify a price just double-click on it and type the new price.
 
-NOTE: _If a price has been defined as “undefined” (see link:#14-2-11-other-prices-other-prices[Other Prices]) it will look as 0 – zero and cannot be modified._
+NOTE: If a price has been defined as “undefined” (see <<other-prices,Other Prices>>) it will appear as 0 (zero) and cannot be modified.
 
-NOTE: _Exams, Operations and Medicals prices are automatically created as OPD, IPD, not “daily”, not “undefined”, not “discharge”; see link:#14-2-11-other-prices-other-prices[Other Prices] for more information._
+NOTE: Exams, Operations and Medicals prices are automatically created as OPD, IPD, not “daily”,
+not “undefined”, and not “discharge”; see <<other-prices,Other Prices>> for more information.
 
 When all modifications have been made, you can store them permanently in the system by pressing *[.underline]##S##AVE* button. After some instants a confirmation message will inform you about the success of the operation:
 
 image:image178.png[Prices Browser_saved.PNG,width=268,height=118]
 
+[#pricelists]
 ====  14.9.1 Pricelists (_Manage Lists_)
 
-Once you’ve pressed on *_Manage Lists_* button from the *_Prices Browser_* window you access the *_List Browser_* window as showed below:
+Once you have pressed on *_Manage Lists_* button from the *_Prices Browser_* window you access the *_List Browser_* window as shown below:
 
 image:image179.png[List Browser.PNG,width=500,height=274]
 
@@ -2598,11 +2808,12 @@ ____
 
 In editing mode, you can change all data related to the list.
 
-The Lists defined in this functionality will be reflected in the Accounting module (see link:#8-2-1-insert-a-new-bill-new-bill[Insert a new bill] in this document).
+The Lists defined in this functionality will be reflected in the Accounting module (see
+<<insert-a-new-bill,Insert a new bill>> in this document).
 
 === 14.10 Supplier ([.underline]#Supplier#)
 
-Once you’ve pressed on *S[.underline]##upplier##* button from the *_General Data_* menu you access the *_Supplier Browser_* window as showed below:
+Once you have pressed on *S[.underline]##upplier##* button from the *_General Data_* menu you access the *_Supplier Browser_* window as shown below:
 
 image:image182.png[Prices Browser.PNG,width=550,height=231]
 
@@ -2633,17 +2844,21 @@ In order to insert a new Supplier, you must input the following data:
 
 Then click *[.underline]##O##K* to save the new Supplier.
 
-In order to Edit Supplier information, in the *_Supplier browser_* highlights the Supplier and click the *[.underline]##E##dit* button to open the *_Edit Supplier_* window. Perform modifications and click *[.underline]##O##k* to save.
+In order to Edit Supplier information, in the *_Supplier browser_* highlights the Supplier and 
+click the *[.underline]##E##dit* button to open the *_Edit Supplier_* window. 
+Perform modifications and click *[.underline]##O##K* to save.
 
-In order to delete a Supplier, in the *_Supplier browser_* highlights the Supplier and click the *D[.underline]##elete##* button to delete the selected Supplier.
+In order to delete a Supplier, in the *_Supplier browser_* highlights the Supplier and 
+click the *D[.underline]##elete##* button to delete the selected Supplier.
 
+[#sms-manager]
 === 14.11 SMS Manager ([.underline]#SMS Manager#)
 
-WARNING: _SMS pricing depend by the SMS Provider (GSM or HTTP) and are not related to this software!_
+WARNING: SMS pricing is set and collected by the SMS Provider (GSM or HTTP) and are not related to this software.
 
-NOTE: _Sending SMS in OpenHospital require that the Gateway is well configured. You can use a GSM gateway or a WebApi Gateway. Ask your administrator how to do it or read the Administrator’s Guide._
+NOTE: Sending SMS in Open Hospital requires that the Gateway is well configured. You can use a GSM gateway or a WebApi Gateway. Ask your administrator how to do it or read the _Administrator’s Guide_.
 
-Once you’ve pressed on *SMS Manager* button from the *_General Data_* menu you access the *_SMS Manager_* window as showed below:
+Once you have pressed on *SMS Manager* button from the *_General Data_* menu you access the *_SMS Manager_* window as shown below:
 
 image:image184.png[Prices Browser.PNG,width=438,height=327]
 
@@ -2670,9 +2885,10 @@ Then click *[.underline]##O##K* to save the new SMS. If the scheduled data and t
 
 In order to delete a SMS, highlights it and click the *[.underline]##D##elete* button to delete the SMS.
 
+[#users-groups]
 == 15 Users & Groups ([.underline]##F##ile -> _[.underline]##U##sers_)
 
-The User Menu can be enabled or disabled by changing the _SINGLEUSER_ flag in the configuration file**.** Ask to your Administrator how to do it or read the _Administrator’s Guide_.
+The User Menu can be enabled or disabled by changing the _SINGLEUSER_ flag in the configuration file**.** Ask your Administrator how to do it or read the _Administrator’s Guide_.
 
 If _SINGLEUSER_ is set to NO the following login window will appear when the program starts:
 
@@ -2680,17 +2896,17 @@ image:image187.png[Login.PNG,width=305,height=148]
 
 Once successfully logged in the system, you have been enabled by the administrator you will find the *_[.underline]##U##sers_* button in the *_File_* submenu.
 
-Once you’ve pressed on *_[.underline]##U##sers_* button from the *_File_* submenu you access the *_Users_* submenu as showed below:
+Once you have pressed on *_[.underline]##U##sers_* button from the *_File_* submenu you access the *_Users_* submenu as shown below:
 
 image:image188.png[Users & Groups.PNG,width=153,height=136]
 
-OpenHospital allows the management of users organized into groups; each group is characterized by different permissions assigned by the Administrator.
+Open Hospital allows the management of users organized into groups; each group is characterized by different permissions assigned by the Administrator.
 
 Before to register a new user in the system, we should ensure there is a group with its related rights, where the user can be added to.
 
 === 15.1 Groups ([.underline]##G##roups)
 
-Once you’ve pressed on *[.underline]##G##roups* button from the *_Users_* submenu you access the *_Groups Browser_* window as showed below:
+Once you have pressed on *[.underline]##G##roups* button from the *_Users_* submenu you access the *_Groups Browser_* window as shown below:
 
 image:image189.png[Groups Browser.PNG,width=642,height=180]
 
@@ -2706,7 +2922,7 @@ By pressing the *Group[.underline]##M##enu* button, the *_Menu Item Browser_* wi
 
 image:image190.png[image,width=280,height=350]
 
-The window shows the full set of function of OpenHospital in a tree format:
+The window shows the full set of function of Open Hospital in a tree format:
 
 * main is the “trunk”: the main menu
 * *Blue* nodes are the “branches”: menus and windows
@@ -2726,7 +2942,7 @@ image:image194.png[../../Screen%20Shot%202019-07-26%20at%2016.08.01.png,width=64
 
 === 15.2 Users ([.underline]##U##sers)
 
-Once you’ve pressed on *[.underline]##U##sers* button from the *_Users_* submenu you access the *_Users Browser_* window as showed below:
+Once you have pressed on *[.underline]##U##sers* button from the *_Users_* submenu you access the *_Users Browser_* window as shown below:
 
 image:image195.png[image,width=621,height=305]
 
@@ -2748,16 +2964,17 @@ Each user is so identified by a name, a description and a *password* that can be
 
 <<<
 
+[#worksheet]
 == 16 Worksheet ([.underline]##W##orksheet)
 
-Since OpenHospital *v1.11* a new feature called *Worksheet* allows to manage and print the list of appointments scheduled to date.
+Since Open Hospital *v1.11* a new feature called *Worksheet* allows to manage and print the list of appointments scheduled to date.
 
 .Click with the mouse on the button or press "Alt + W" to enter the *Worksheet* page
-[#16-default-main-menu]
+[#default-main-menu-16]
 [caption="Main Menu: "]
 image:image0_DefaultMainMenu.png[Default Main Menu,width=250,height=627]
 
-The _Worksheet_ module works by Ward (Department) so you will be asket to select one first
+The _Worksheet_ module works by Ward (Department) so you will be asked to select one first
 
 image:image245.png[image,width=600,height=265]
 
@@ -2766,7 +2983,7 @@ Once selected the ward (it is possible to switch to another ward at anytime), a 
 image:image246.png[image,width=600,height=265]
 
 It is possible to select another date with the *Go to date* field, and reset back to today with the button *Today*. 
-In any case, the window will _[.underline]#always#_ show a choosen date on the left and its following day on the right.
+In any case, the window will _[.underline]#always#_ show a chosen date on the left and its following day on the right.
 
 The functions available from this window are:
 
@@ -2776,7 +2993,7 @@ The functions available from this window are:
 * *<-[.underline]##P##rev*: to browse one day before
 * *[.underline]##C##lose*: to close the window
 
-TIP: _To schedule a visit can be done also from *Therapy Management* module, see <<_10_10_therapy_management_therapy>>
+TIP: To schedule a visit can be done also from *Therapy Management* module, see <<therapy-management,Therapy management>>
 
 <<<
 
@@ -2785,6 +3002,3 @@ TIP: _To schedule a visit can be done also from *Therapy Management* module, see
 image:by-sa.png[bysa,width=88,height=31,link="http://creativecommons.org/licenses/by-sa/4.0"] [.small]#Informatici Senza Frontiere Onlus, 2020#
 pass:[<br>][.small]#User's Guide, &#169; 2020 by https://www.informaticisenzafrontiere.org/[Informatici Senza Frontiere Onlus]#
 pass:[<br>][.small]#Policies is made available under a http://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0] International License: http://creativecommons.org/licenses/by-sa/4.0/.#
-
-
-


### PR DESCRIPTION
The major (original) change was to fix up the links/cross-references within the document.

In the process other changes where made which included:

- OpenHospital -> Open Hospital
- spelling changes
- grammar changes
- consistency changes
- correcting bad anchor definitions

I did start to do some more major editing but decided there were enough changes here to get this out and merged.  That would allow for closing the JIRA issue.
