### PR TITLE
Chore: information is plural

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -1589,7 +1589,7 @@ Starting with Open Hospital version 1.7 a default txtPrinter.properties file is 
 
 [source, properties]
 ----
-# This file contains text printing informations
+# This file contains text printing information
 # MODE = TXT, PDF or ZPL
 USE_DEFAULT_PRINTER=yes
 PRINT_AS_PAID=no
@@ -1636,7 +1636,7 @@ Open Hospital 1.7 and greater versions, come with the xmpp.properties file set a
 
 [source, properties]
 ----
-# This file contains Xmpp Server informations
+# This file contains Xmpp Server information
 DOMAIN=127.0.0.1
 PORT=5222
 ----


### PR DESCRIPTION
`information` is plural; no need to add `s`.

There is another PR coming to fix the actual text files too.