### PR TITLE
OP-138 - Patient Photo to File System Repository (#108)

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -1552,6 +1552,8 @@ The following table shows the default value and the allowed ones:
 
 Open Hospital can save the user's profile picture in the database or on the file system.
 
+NOTE: The maximum size for patient's profile picture is limited to 4096 bytes. If a bigger image is provided it will automatically resized.
+
 If the PATIENTPHOTOSTORAGE parameter is set to a path (different from "DB"), Open Hospital searches for the profile picture in the specified path.
 
 If the PATIENTPHOTOSTORAGE parameter is set to "DB", then Open Hospital searches for the patient profile picture in the DB.

--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -1552,11 +1552,11 @@ The following table shows the default value and the allowed ones:
 
 Open Hospital can save the user's profile picture in the database or on the file system.
 
-NOTE: The maximum size for patient's profile picture is limited to 4096 bytes. If a bigger image is provided it will automatically resized.
+NOTE: The maximum size for patient's profile picture is limited to 4096 bytes. If a bigger image is provided, it will automatically resized.
 
-If the PATIENTPHOTOSTORAGE parameter is set to a path (different from "DB"), Open Hospital searches for the profile picture in the specified path.
+If the PATIENTPHOTOSTORAGE parameter is set to a path (different from "DB"), Open Hospital looks for or save the patient's profile picture in the specified path.
 
-If the PATIENTPHOTOSTORAGE parameter is set to "DB", then Open Hospital searches for the patient profile picture in the DB.
+If the PATIENTPHOTOSTORAGE parameter is set to "DB", then Open Hospital looks for or save the patient's profile picture in the DB.
 
 
 By default, PATIENTPHOTOSTORAGE is set to "DB".

--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -693,6 +693,7 @@ DEBUG=no
 USERSLISTLOGIN=no
 STRONGPASSWORD=yes
 STRONGLENGTH=10
+PATIENTPHOTOSTORAGE=DB
 ----
 
 Every line is composed of a KEY and a value:
@@ -1502,6 +1503,10 @@ image:image27.png[UsersListLogin.png,width=375,height=139]
 
 image:image24.png[Login.png,width=375,height=139]
 
+By default, USERSLISTLOGIN is set to no.
+
+NOTE: An application restart is required to apply the modified setting.
+
 [#strongpasword]
 ==== 3.1.37 STRONGPASSWORD
 
@@ -1531,6 +1536,28 @@ The following table shows the default value and the allowed ones:
 |===
 
 The value of STRONGLENGTH is the minimum length of a user's password.
+
+NOTE: An application restart is required to apply the modified setting.
+
+
+==== 3.1.39 PATIENTPHOTOSTORAGE
+
+The following table shows the default value and the allowed ones:
+
+[cols=",,",options="header",]
+|===
+|Key |Default Value |Valid Values
+|PATIENTPHOTOSTORAGE |DB |DB, _<path_to_folder>_
+|===
+
+Open Hospital can save the user's profile picture in the database or on the file system.
+
+If the PATIENTPHOTOSTORAGE parameter is set to a path (different from "DB"), Open Hospital searches for the profile picture in the specified path.
+
+If the PATIENTPHOTOSTORAGE parameter is set to "DB", then Open Hospital searches for the patient profile picture in the DB.
+
+
+By default, PATIENTPHOTOSTORAGE is set to "DB".
 
 NOTE: An application restart is required to apply the modified setting.
 

--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -1554,9 +1554,9 @@ Open Hospital can save the user's profile picture in the database or on the file
 
 NOTE: The maximum size for patient's profile picture is limited to 4096 bytes. If a bigger image is provided, it will automatically resized.
 
-If the PATIENTPHOTOSTORAGE parameter is set to a path (different from "DB"), Open Hospital looks for or save the patient's profile picture in the specified path.
+If the PATIENTPHOTOSTORAGE parameter is set to a path (that is, not "DB"), then Open Hospital looks for or saves the patient's profile picture in the specified path.
 
-If the PATIENTPHOTOSTORAGE parameter is set to "DB", then Open Hospital looks for or save the patient's profile picture in the DB.
+If the PATIENTPHOTOSTORAGE parameter is set to "DB", then Open Hospital looks for or saves the patient's profile picture in the Open Hospital database.
 
 
 By default, PATIENTPHOTOSTORAGE is set to "DB".


### PR DESCRIPTION
See OP-138.
Paired with:
- https://github.com/informatici/openhospital-core/pull/721
- https://github.com/informatici/openhospital-gui/pull/1256

Authored-by: @AndreiDodu:
* load profile picture from filesystem completed
* Fixed OH documentation following David's advices
* Reduced parameter to only PATIENTPHOTOSTORAGE
* Fix PATIENTPHOTOSTORAGE table
* Resolve conflicts

Co-authored-by: Alessandro Domanico <alessandro.domanico@yahoo.it>