### PR TITLE
OP-214 Fix report bundle fallback for EN language

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2294,7 +2294,10 @@ Each report consists of two files:
 * a .*jrxml* file: JasperReport XML file, that can be modified with Jaspersoft® Studio (see below)
 * a .*jasper* file: Jasper file, which is the compiled version of the jrxml report, suitable to be run in Open Hospital
 
-NOTE: Some reports could also have more than one *.properties* file; this means that the report has been translated into different languages (the default is English). At least the default *.properties* file should contain the *jTitle* property that defines the name of the report visualized in the Open Hospital application, otherwise the application will not show it (this can be useful for subreports).
+Reports that support translation also include:
+
+* a .*properties* file: default translation file, placed alongside the `.jasper` file. This file must be written in *English*, as it serves as the fallback for all languages that do not have a specific translation. It must contain the *jTitle* property that defines the name of the report visualized in the Open Hospital application, otherwise the application will not show it (this can be useful for subreports).
+* language-specific .*properties* files: placed in a `<lang>/` subfolder (e.g., `it/Laboratory.properties` for Italian), with the same filename as the default. If no language-specific file is found for the current language, Open Hospital falls back to the JRXML default automatically.
 
 In order to create / modify a report, it is possibile to use a free application, https://community.jaspersoft.com/download-jaspersoft/community-edition/[TIBCO Jaspersoft® Studio] version 6.14.0 or later.
 To define a new report it is possible to start from scratch or modify an existing Open Hospital report:

--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2299,6 +2299,8 @@ Reports that support translation also include:
 * a .*properties* file: default translation file, placed alongside the `.jasper` file. This file must be written in *English*, as it serves as the fallback for all languages that do not have a specific translation. It must contain the *jTitle* property that defines the name of the report visualized in the Open Hospital application, otherwise the application will not show it (this can be useful for subreports).
 * language-specific .*properties* files: placed in a `<lang>/` subfolder (e.g., `it/Laboratory.properties` for Italian), with the same filename as the default. If no language-specific file is found for the current language, Open Hospital falls back to the JRXML default automatically.
 
+NOTE: Translations in languages other than English are managed via https://app.transifex.com/informatici-senza-frontiere-onlus/openhospital/dashboard/[Transifex], which will automatically attempt to provide translations for new files and changes.
+
 In order to create / modify a report, it is possibile to use a free application, https://community.jaspersoft.com/download-jaspersoft/community-edition/[TIBCO Jaspersoft® Studio] version 6.14.0 or later.
 To define a new report it is possible to start from scratch or modify an existing Open Hospital report:
 


### PR DESCRIPTION
See OP-214.

As continuation of #274  we are going to fix the "en" fallback as Transifex doesn't need `en/` folder.