### PR TITLE
OP-896 Document the PASSWORDLEASE password lease policy

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -745,6 +745,7 @@ USERSLISTLOGIN=no
 PASSWORDTRIES=5
 PASSWORDLOCKTIME=60
 PASSWORDIDLE=365
+PASSWORDLEASE=0
 
 # telemetry
 TELEMETRYENABLED=yes
@@ -1643,6 +1644,25 @@ The following table shows the default value and the allowed ones:
 
 The value of PASSWORDIDLE specifies the maximum number of days that an account can be unused before being locked and requiring intervention by the administrator.
 To disable this check set PASSWORDIDLE to 0.
+
+NOTE: An application restart is required to apply the modified setting.
+
+[#passwordlease]
+==== 3.1.41 PASSWORDLEASE
+
+The following table shows the default value and the allowed ones:
+
+[cols=",,",options="header",]
+|===
+|Key |Default Value | Allowed Values
+|PASSWORDLEASE | 0 | a positive integer value greater than or equal to 0; the unit of time is days
+|===
+
+The value of PASSWORDLEASE specifies the maximum number of days a password remains valid (the password lease). When the lease expires, the user is required to change the password at the next login, before being granted access to the application, both in the desktop GUI and in the web UI. To disable the password lease set PASSWORDLEASE to 0 (the default).
+
+In addition, a password assigned by an administrator (when creating a user or resetting another user's password) must be changed by the user at the first login, regardless of the PASSWORDLEASE value.
+
+NOTE: For production environments a value of 90 days is recommended.
 
 NOTE: An application restart is required to apply the modified setting.
 

--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -1647,25 +1647,6 @@ To disable this check set PASSWORDIDLE to 0.
 
 NOTE: An application restart is required to apply the modified setting.
 
-[#passwordlease]
-==== 3.1.41 PASSWORDLEASE
-
-The following table shows the default value and the allowed ones:
-
-[cols=",,",options="header",]
-|===
-|Key |Default Value | Allowed Values
-|PASSWORDLEASE | 0 | a positive integer value greater than or equal to 0; the unit of time is days
-|===
-
-The value of PASSWORDLEASE specifies the maximum number of days a password remains valid (the password lease). When the lease expires, the user is required to change the password at the next login, before being granted access to the application, both in the desktop GUI and in the web UI. To disable the password lease set PASSWORDLEASE to 0 (the default).
-
-In addition, a password assigned by an administrator (when creating a user or resetting another user's password) must be changed by the user at the first login, regardless of the PASSWORDLEASE value.
-
-NOTE: For production environments a value of 90 days is recommended.
-
-NOTE: An application restart is required to apply the modified setting.
-
 ==== 3.1.41 PATIENTPHOTOSTORAGE
 
 The following table shows the default value and the allowed ones:
@@ -1761,6 +1742,25 @@ image:image69.png[image,width=847,height=522]
 This is the URL of the online configuration/parameters file.
 
 NOTE: This setting is not meant to be modified by the user.
+
+[#passwordlease]
+==== 3.1.47 PASSWORDLEASE
+
+The following table shows the default value and the allowed ones:
+
+[cols=",,",options="header",]
+|===
+|Key |Default Value | Allowed Values
+|PASSWORDLEASE | 0 | a positive integer value greater than or equal to 0; the unit of time is days
+|===
+
+The value of PASSWORDLEASE specifies the maximum number of days a password remains valid (the password lease). When the lease expires, the user is required to change the password at the next login, before being granted access to the application, both in the desktop GUI and in the web UI. To disable the password lease set PASSWORDLEASE to 0 (the default).
+
+In addition, a password assigned by an administrator (when creating a user or resetting another user's password) must be changed by the user at the first login, regardless of the PASSWORDLEASE value.
+
+NOTE: For production environments a value of 90 days is recommended.
+
+NOTE: An application restart is required to apply the modified setting.
 
 [#database-properties]
 === 3.2 database.properties


### PR DESCRIPTION
## OP-896 — Password lease (documentation)

Documents the new password lease policy in the Administrator Manual.

### Changes
- Adds `PASSWORDLEASE` to the security settings listing.
- New `PASSWORDLEASE` section describing: the parameter (days; `0` = disabled), the forced password change at next login on lease expiry, the forced change at first login for administrator-assigned passwords, the desktop and web user experience, and the recommended 90-day value for production.

Part of the OP-896 multi-repo change (core informatici/openhospital-core#1596, api informatici/openhospital-api#585, gui informatici/openhospital-gui#2211, ui informatici/openhospital-ui#775).

JIRA: https://openhospital.atlassian.net/browse/OP-896
