### PR TITLE
OP-1061 Document that price lists use the hospital global currency

### DIFF
--- a/doc_user/UserManual.adoc
+++ b/doc_user/UserManual.adoc
@@ -3489,7 +3489,9 @@ By pressing the *[.underline]##E##dit* button, the *_Edit List_* window is shown
 
 image:image181.png[Edit List]
 
-In editing mode, any of the data related to the list can be changed.
+In editing mode, any of the data related to the list can be changed, except the *Currency*.
+
+NOTE: The *Currency* is no longer entered manually: all price lists share the hospital's global currency (defined in the Hospital information). The field is shown read-only for reference.
 
 The lists defined are used in the Accounting module (see
 <<insert-a-new-bill,Insert a new bill>> in this document).


### PR DESCRIPTION
## What & why

Documentation note for OP-1061: price lists now use the hospital's global currency (read-only), instead of a free-text per-list currency.

## Changes

- `doc_user/UserManual.adoc` (Price Lists / Edit List section): note that the *Currency* is set to the hospital global currency and is not editable.

## Companion PR

GUI change: informatici/openhospital-gui (same branch `OP-1061-pricelist-global-currency`).

Jira: OP-1061
