### PR TITLE
OP-1099 Document the new uniqueness constraints on user-related tables

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2414,7 +2414,7 @@ _sql/update_ folder (e.g.):
 | 1.13 | 1.14 | _update_1_13-1_14.sql_
 |===
 
-NOTE: From this release the user-related tables enforce additional uniqueness at the database level: a permission name (`OH_PERMISSIONS.P_NAME`) and each (user group, permission) pair (`OH_GROUPPERMISSION`) must be unique. Duplicate (user group, permission) rows are removed automatically by the update script, but duplicate permission names are NOT (a permission may be referenced elsewhere): if any exist the update fails fast without changing data, so resolve the duplicates reported by the pre-flight queries and then re-run.
+NOTE: The user-related tables enforce uniqueness at the database level: a permission name (`OH_PERMISSIONS.P_NAME`) and each (user group, permission) pair (`OH_GROUPPERMISSION`) must be unique. When running the database update, duplicate (user group, permission) rows are removed automatically by the update script, but duplicate permission names are NOT (a permission may be referenced elsewhere): if any exist the update fails fast without changing data, so resolve the duplicates reported by the pre-flight queries and then re-run.
 
 To perform the database update process follow these steps:
 

--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2414,6 +2414,8 @@ _sql/update_ folder (e.g.):
 | 1.13 | 1.14 | _update_1_13-1_14.sql_
 |===
 
+NOTE: From this release the user-related tables enforce additional uniqueness at the database level: a permission name (`OH_PERMISSIONS.P_NAME`) and each (user group, permission) pair (`OH_GROUPPERMISSION`) must be unique. Duplicate (user group, permission) rows are removed automatically by the update script, but duplicate permission names are NOT (a permission may be referenced elsewhere): if any exist the update fails fast without changing data, so resolve the duplicates reported by the pre-flight queries and then re-run.
+
 To perform the database update process follow these steps:
 
 . Close the program if it is still running


### PR DESCRIPTION
## What & why

Documentation note for OP-1099: from this release the user-related tables enforce additional uniqueness (permission name, and each user-group/permission pair).

## Changes

- `doc_admin/AdminManual.adoc` (Update Database section): NOTE that duplicate (user group, permission) rows are removed automatically by the update script, while duplicate permission names are NOT and will make the update fail fast until resolved manually.

## Companion PR

Core change: informatici/openhospital-core (same branch `OP-1099-user-jpa-constraints`).

Jira: OP-1099
