### PR TITLE
OP-890 Document REST API information-disclosure hardening

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2278,7 +2278,7 @@ Then edit the Arabic bundle file and set the LANGUAGE parameter to *ar* to start
 
 <<<
 
-=== 3.11 application.properties (REST API) - security hardening
+=== 3.12 application.properties (REST API) - security hardening
 
 The REST API server (_rsc/application.properties_) ships with settings that prevent technical and version information from being disclosed in HTTP responses (STRIDE I03 - Information Disclosure):
 
@@ -2295,7 +2295,7 @@ spring.mvc.throw-exception-if-no-handler-found=true
 server.server-header=
 ----
 
-Keep these settings enabled in production. The Spring Boot Actuator is not bundled, so management endpoints (e.g. _/actuator_) already return _404_, while the Swagger UI stays available. When the API is published behind a reverse proxy (nginx/Apache), strip the proxy's own `Server` and `X-Powered-By` headers there as well (e.g. `server_tokens off;` in nginx).
+Keep these settings enabled in production. The Spring Boot Actuator is not bundled, so management endpoints (e.g. _/actuator_) already returns _404_, while the Swagger UI stays available. When the API is published behind a reverse proxy (nginx/Apache), strip the proxy's own `Server` and `X-Powered-By` headers there as well (e.g. `server_tokens off;` in nginx).
 
 <<<
 

--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2278,6 +2278,27 @@ Then edit the Arabic bundle file and set the LANGUAGE parameter to *ar* to start
 
 <<<
 
+=== 3.11 application.properties (REST API) - security hardening
+
+The REST API server (_rsc/application.properties_) ships with settings that prevent technical and version information from being disclosed in HTTP responses (STRIDE I03 - Information Disclosure):
+
+[source,properties]
+----
+# Do not leak messages, stack traces or exception class names in error responses
+server.error.include-message=never
+server.error.include-stacktrace=never
+server.error.include-exception=false
+server.error.include-binding-errors=never
+# Return a clean 404 for unknown paths
+spring.mvc.throw-exception-if-no-handler-found=true
+# Suppress the server identification (version) header
+server.server-header=
+----
+
+Keep these settings enabled in production. The Spring Boot Actuator is not bundled, so management endpoints (e.g. _/actuator_) already return _404_, while the Swagger UI stays available. When the API is published behind a reverse proxy (nginx/Apache), strip the proxy's own `Server` and `X-Powered-By` headers there as well (e.g. `server_tokens off;` in nginx).
+
+<<<
+
 [#reports]
 == 4 Reports
 


### PR DESCRIPTION
## What & why

Documentation for OP-890 (Information Disclosure hardening of the REST API).

## Changes

- `doc_admin/AdminManual.adoc`: new section "3.11 application.properties (REST API) - security hardening" describing the error-masking and server-header settings, noting the Actuator is not bundled (so `/actuator` already 404) and Swagger stays available, and that a reverse proxy should strip its own `Server`/`X-Powered-By` headers.

## Companion PR

API change: informatici/openhospital-api (same branch `OP-890-information-disclosure-hardening`).

Jira: OP-890
