### PR TITLE
OP-892 Document the admission sex/age snapshot for anonymous statistics

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2414,6 +2414,8 @@ _sql/update_ folder (e.g.):
 | 1.13 | 1.14 | _update_1_13-1_14.sql_
 |===
 
+NOTE: From this release each admission stores a snapshot of the patient's sex and age at admission time (`OH_ADMISSION.ADM_SEX` / `ADM_AGE`). This allows aggregate statistics (e.g. admissions by disease, sex and age) to be produced without joining the patient table, i.e. without exposing personal data. The update script adds the two columns and back-fills them for existing admissions (age is computed at the admission date); admissions whose patient has no birth date get a `NULL` age.
+
 To perform the database update process follow these steps:
 
 . Close the program if it is still running

--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2412,6 +2412,7 @@ _sql/update_ folder (e.g.):
 | 1.11 | 1.12 | _update_1_11-1_12.sql_
 | 1.12 | 1.13 | _update_1_12-1_13.sql_
 | 1.13 | 1.14 | _update_1_13-1_14.sql_
+| 1.14 | 1.15 | _update_1_14-1_15.sql_
 |===
 
 NOTE: From this release each admission stores a snapshot of the patient's sex and age at admission time (`OH_ADMISSION.ADM_SEX` / `ADM_AGE`). This allows aggregate statistics (e.g. admissions by disease, sex and age) to be produced without joining the patient table, i.e. without exposing personal data. The update script adds the two columns and back-fills them for existing admissions (age is computed at the admission date); admissions whose patient has no birth date get a `NULL` age.


### PR DESCRIPTION
## What & why

Documentation for OP-892 (core scope): admissions now store a snapshot of the patient's sex and age at admission time for anonymous aggregate statistics.

## Changes

- `doc_admin/AdminManual.adoc` (Update Database): NOTE describing the new `OH_ADMISSION.ADM_SEX` / `ADM_AGE` columns, their purpose (anonymous statistics without querying patient PII), and the back-fill behaviour.

## Companion PR

Core change: informatici/openhospital-core (same branch `OP-892-separate-personal-data`).

Jira: OP-892
