### PR TITLE
OP-891 Document error masking in the Admin Manual

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -827,6 +827,8 @@ be required on other clients, with the same defined user and group.
 
 WARNING: Data security must never be left solely to the application but it must include proper network architecture and a rigid configuration of the clients.
 
+NOTE: To avoid information disclosure, Open Hospital masks internal errors: users and API clients only receive generic, user-facing error messages and never see stack traces, SQL statements, or internal exception class names. The full technical details of every error are written only to the application log files, where administrators can inspect them.
+
 
 ==== 3.1.3 AUTOMATICLOT
 


### PR DESCRIPTION
## OP-891 — Information Disclosure 2/2: Errors masking (I04) — doc part

Adds a NOTE in the Admin Manual Security section explaining that Open Hospital masks internal errors: users and API clients receive only generic, user-facing messages and never see stack traces, SQL statements or internal exception class names; full technical details are written only to the application log files.

Companion API PR: informatici/openhospital-api#589