### PR TITLE
OP-1300 Document the LOTCOSTVARIANCEPERCENT setting

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -720,6 +720,7 @@ AUTOMATICLOT_IN=no
 AUTOMATICLOT_OUT=no
 AUTOMATICLOTWARD_TOWARD=no
 LOTWITHCOST=yes
+LOTCOSTVARIANCEPERCENT=50
 PHARMACEUTICALORDER=PharmaceuticalOrder
 PHARMACEUTICALSTOCK=PharmaceuticalStock_ver4
 PHARMACEUTICALSTOCKLOT=PharmaceuticalStock_ver5
@@ -870,10 +871,13 @@ The following table shows the default value and the allowed ones:
 |===
 |Key |Default Value |Valid Values
 |LOTWITHCOST |yes |yes, no
+|LOTCOSTVARIANCEPERCENT |50 |0 (disabled) or any positive integer
 |===
 
 Open Hospital allows for managing the cost of medicals in the main pharmacy
 (see link:https://github.com/informatici/openhospital-doc/blob/develop/doc_user/UserManual.adoc#4-2-2-2-insert-stock-charging-movement-charge[4.2.2.2 Insert stock charging movement] in the User's Guide).
+
+When *LOTWITHCOST = yes*, *LOTCOSTVARIANCEPERCENT* sets the maximum allowed percentage deviation between the cost entered for a new lot and the average cost of the previous lots of the same medical. When the entered cost exceeds this deviation, the application asks the user to confirm before accepting it, helping to catch data-entry errors. Setting it to *0* disables the check.
 
 NOTE: An application restart is required to apply the modified setting.
 


### PR DESCRIPTION
## OP-1300 — Lot Costs variance check (documentation)

Documents the new `LOTCOSTVARIANCEPERCENT` setting in the Admin Manual, alongside `LOTWITHCOST` (§3.1.4):

- Added `LOTCOSTVARIANCEPERCENT=50` to the pharmacy settings listing.
- Added the setting to the LOTWITHCOST table (`50` / `0 (disabled) or any positive integer`) and a short paragraph explaining that, when `LOTWITHCOST=yes`, it sets the maximum allowed percentage deviation between a new lot's cost and the average cost of the medical's previous lots; beyond it the user is asked to confirm. `0` disables the check.

### Companion PRs (same branch `OP-1300-lot-cost-variance`)
- core: informatici/openhospital-core#1630
- gui: informatici/openhospital-gui#2228

Jira: https://openhospital.atlassian.net/browse/OP-1300
