### PR TITLE
OP-887 Document the GDPR patient data export

### DIFF
--- a/doc_admin/AdminManual.adoc
+++ b/doc_admin/AdminManual.adoc
@@ -2513,3 +2513,106 @@ You can contact us at: https://www.open-hospital.org/contact and specify:
 image:by-sa.png[bysa,width=88,height=31,link="https://creativecommons.org/licenses/by-sa/4.0/"] [.small]#Informatici Senza Frontiere Onlus, 2022#
 pass:[<br>][.small]#Administrator’s Guide, &#169; 2023 by https://www.informaticisenzafrontiere.org/[Informatici Senza Frontiere Onlus]#
 pass:[<br>][.small]#Policies is made available under a https://creativecommons.org/licenses/by-sa/4.0//[Creative Commons Attribution-ShareAlike 4.0] International License: https://creativecommons.org/licenses/by-sa/4.0//.#
+
+<<<
+
+== 9 GDPR - Data Portability (Art. 20)
+
+=== 9.1 Legal basis
+
+Article 20 of the EU General Data Protection Regulation (GDPR) grants data subjects the right to receive the personal data
+concerning them, which they have provided to a controller, in a structured, commonly used and machine-readable format.
+To support this right, Open Hospital can export, for a single patient, the patient record together with all the clinical
+and administrative records connected to it, in an open format (JSON, or CSV via the REST API).
+
+=== 9.2 The patient.export permission
+
+The export function is protected by a dedicated permission named *patient.export*.
+It applies to all channels: the GUI button, the REST API endpoint and the Web UI button are only available to users
+belonging to a group that holds this permission.
+
+A fresh installation (or a demo database) grants *patient.export* to the *admin* group only.
+
+To grant the permission to another user group, use the permission editor in the Web UI (_Settings_ -> _User Groups_),
+or run the following SQL statement on the database (example for the group `doctor`):
+
+[source,shell]
+----
+MariaDB> INSERT INTO oh_grouppermission (GP_ID, GP_UG_ID_A, GP_P_ID_A, GP_ACTIVE)
+	 SELECT (SELECT MAX(g.GP_ID) + 1 FROM oh_grouppermission g), 'doctor', p.P_ID_A, '1'
+	 FROM oh_permissions p WHERE p.P_NAME = 'patient.export';
+----
+
+NOTE: The statement looks the permission up by name instead of using a hard-coded numeric ID, so it works regardless
+of the actual `P_ID_A` value assigned on your installation.
+
+=== 9.3 Export procedure
+
+The export can be triggered from three channels; all of them require the *patient.export* permission.
+
+*Desktop GUI (Java client)*
+
+. Open the *_Patient Browser_* window and select the patient;
+. press the *Export Patient Data* button;
+. choose the destination file in the save dialog (the proposed name is `patient_<code>_export.json`);
+. the complete patient data set is written to the selected file as UTF-8 encoded JSON.
+
+*REST API*
+
+The API exposes a dedicated endpoint:
+
+[source,shell]
+----
+GET /patients/{code}/export
+----
+
+* with `Accept: application/json` (or no `Accept` header) the aggregate is returned as JSON;
+* with `Accept: text/csv` the aggregate is returned as CSV, with a `Content-Disposition` attachment header
+(`patient_<code>_export.csv`);
+* the authenticated user must hold the *patient.export* permission, otherwise the request is rejected with HTTP 403;
+* if no patient exists with the given code, the endpoint returns HTTP 404.
+
+*Web UI*
+
+In the patient details view, users with the *patient.export* permission see an *Export patient data* button that
+downloads the JSON document through the browser.
+
+=== 9.4 Export format
+
+The JSON document contains the following groups (empty groups are exported as empty lists, never omitted):
+
+* `patient` - the patient master record;
+* `admissions` - admission/discharge history;
+* `opds` - OPD (outpatient department) visits;
+* `laboratories` - laboratory exams;
+* `therapies` - therapy rows;
+* `operations` - surgical operation rows;
+* `vaccines` - administered vaccines;
+* `examinations` - patient examinations (vital signs, height/weight, etc.);
+* `bills` - bills headers;
+* `billItems` - bill line items (each item carries the ID of the bill it belongs to);
+* `billPayments` - bill payments (each payment carries the ID of the bill it belongs to).
+
+The CSV variant (REST API only) contains one section per group: a `# <group>` marker line, followed by a header row and
+the data rows, with a blank line between sections. Fields are quoted and escaped according to RFC 4180 and the file is
+UTF-8 encoded.
+
+NOTE: Because of the per-group marker lines, the CSV file is a multi-table container rather than a single flat CSV
+table: split it on the `# <group>` markers before feeding the individual sections to a standard CSV parser.
+
+NOTE: The JSON produced by the desktop GUI is serialized from the internal data model, while the REST API serializes
+its data-transfer objects: the two documents contain the same information but some field names differ slightly between
+the two channels.
+
+=== 9.5 Data not included
+
+The export covers the groups listed above. The following patient-linked data are currently *not* included and, if
+requested, must be extracted separately:
+
+* the patient profile photo (excluded from the JSON body in both channels);
+* pharmaceutical stock ward movements (drugs given to the patient from ward stock);
+* visits/appointments;
+* malnutrition control records;
+* patient consensus records;
+* anamnesis (patient history);
+* DICOM images.

--- a/doc_user/UserManual.adoc
+++ b/doc_user/UserManual.adoc
@@ -2660,6 +2660,20 @@ If two patients with a different sex are merged, the operation is not allowed, w
 
 image:image122.png[Patient merge sex]
 
+=== 8.12 Export Patient Data (GDPR)
+
+Open Hospital can export all the data recorded for a single patient (personal record, admissions, OPD visits,
+laboratory exams, therapies, operations, vaccines, examinations and bills) into a single file in JSON format, to
+support the right to data portability established by Article 20 of the GDPR.
+
+To export a patient's data, highlight the patient in the *_Patient Browser_* window and press the
+*Export Patient Data* button; choose the destination file in the dialog and the data is saved as a JSON document.
+The same export is also available from the patient details view of the Web UI.
+
+NOTE: The *Export Patient Data* button is visible only to users whose group has been granted the *patient.export*
+permission (see the _Administrator's Guide_, chapter _GDPR - Data Portability_). By default only the *admin* group
+holds it.
+
 <<<
 
 [#statistics]


### PR DESCRIPTION
See [OP-887](https://openhospital.atlassian.net/browse/OP-887). Documentation for informatici/openhospital-core#1633, informatici/openhospital-api#595, informatici/openhospital-gui#2229 and the web UI PR.

AdminManual: new GDPR section — legal basis (Art. 20, right to data portability), how to grant the `patient.export` permission, the export procedure from both the desktop GUI and the web UI, the JSON/CSV format description, the explicit list of data not included in the export, and a note on the clinical sheet PDF completeness (vaccines, therapies and visits currently missing from the template — follow-up).

UserManual: a note in the patient management section describing the Export Patient Data button.

Screenshots will be added as a follow-up (captured on Linux).


[OP-887]: https://openhospital.atlassian.net/browse/OP-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ